### PR TITLE
cracker updates

### DIFF
--- a/data/jtr/dumb16.conf
+++ b/data/jtr/dumb16.conf
@@ -1,17 +1,22 @@
-# This  software is Copyright (c) 2012-2018 magnum, and it is hereby
+# This  software is Copyright (c) 2012-2020 magnum, and it is hereby
 # released to the general public under the following terms:
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted.
 #
 # Generic implementation of "dumb" exhaustive search of Unicode BMP.
-# Default is to try *all* allocated characters in the BMP of Unicode v11
-# (there's 55,292 of them). Even if a fast format can exhaust two characters
+# Default is to try *all* allocated characters in the BMP of Unicode v13
+# (there's 55,387 of them). Even if a fast format can exhaust two characters
 # in 15 minutes, three characters would take 1.5 years...
 #
 # Note that these modes will handle --max-len differently than normal: They
 # will consider number of characters as opposed to number of bytes. This
 # means you can naturally just use e.g. --max-len=3 for generating all
 # three-character candidates (which may be up to 9 bytes each).
+#
+# Note that the (newer) cracking mode --subsets=full-unicode is way faster than
+# this external mode, although not as easy to adapt to smaller portions of the
+# Unicode space.  See doc/SUBSETS
+
 [List.External:Dumb16]
 int maxlength;            // Maximum password length to try
 int last;                 // Last character position, zero-based
@@ -163,7 +168,7 @@ void init()
 	while (c <= 0x8b4)	// ..to ARABIC LETTER KAF WITH DOT BELOW
 		charset[i++] = c++;
 	c = 0x8b6;		// from ARABIC LETTER BEH WITH SMALL MEEM ABOVE
-	while (c <= 0x8bd)	// ..to ARABIC LETTER AFRICAN NOON
+	while (c <= 0x8c7)	// ..to ARABIC LETTER LAM WITH SMALL ARABIC LETTER TAH ABOVE
 		charset[i++] = c++;
 	c = 0x8d3;		// from ARABIC SMALL LOW WAW
 	while (c <= 0x8ff)	// ..to ARABIC MARK SIDEWAYS NOON GHUNNA
@@ -300,7 +305,7 @@ void init()
 	charset[i++] = 0xb48;	// ORIYA VOWEL SIGN AI
 	charset[i++] = 0xb4b;	// ORIYA VOWEL SIGN O
 	charset[i++] = 0xb4d;	// ORIYA SIGN VIRAMA
-	charset[i++] = 0xb56;	// ORIYA AI LENGTH MARK
+	charset[i++] = 0xb55;	// ORIYA SIGN OVERLINE
 	charset[i++] = 0xb57;	// ORIYA AU LENGTH MARK
 	charset[i++] = 0xb5c;	// ORIYA LETTER RRA
 	charset[i++] = 0xb5d;	// ORIYA LETTER RHA
@@ -373,7 +378,7 @@ void init()
 	c = 0xc66;		// from TELUGU DIGIT ZERO
 	while (c <= 0xc6f)	// ..to TELUGU DIGIT NINE
 		charset[i++] = c++;
-	c = 0xc78;		// from TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR
+	c = 0xc77;		// from TELUGU SIGN SIDDHAM
 	while (c <= 0xc7f)	// ..to TELUGU SIGN TUUMU
 		charset[i++] = c++;
 // 0C80..0CFF; Kannada
@@ -411,9 +416,6 @@ void init()
 	charset[i++] = 0xcf2;	// KANNADA SIGN UPADHMANIYA
 // 0D00..0D7F; Malayalam
 	c = 0xd00;		// from MALAYALAM SIGN COMBINING ANUSVARA ABOVE
-	while (c <= 0xd03)	// ..to MALAYALAM SIGN VISARGA
-		charset[i++] = c++;
-	c = 0xd05;		// from MALAYALAM LETTER A
 	while (c <= 0xd0c)	// ..to MALAYALAM LETTER VOCALIC L
 		charset[i++] = c++;
 	charset[i++] = 0xd0e;	// MALAYALAM LETTER E
@@ -433,7 +435,7 @@ void init()
 	while (c <= 0xd7f)	// ..to MALAYALAM LETTER CHILLU K
 		charset[i++] = c++;
 // 0D80..0DFF; Sinhala
-	charset[i++] = 0xd82;	// SINHALA SIGN ANUSVARAYA
+	charset[i++] = 0xd81;	// SINHALA SIGN CANDRABINDU
 	charset[i++] = 0xd83;	// SINHALA SIGN VISARGAYA
 	c = 0xd85;		// from SINHALA LETTER AYANNA
 	while (c <= 0xd96)	// ..to SINHALA LETTER AUYANNA
@@ -468,23 +470,15 @@ void init()
 // 0E80..0EFF; Lao
 	charset[i++] = 0xe81;	// LAO LETTER KO
 	charset[i++] = 0xe82;	// LAO LETTER KHO SUNG
-	charset[i++] = 0xe87;	// LAO LETTER NGO
-	charset[i++] = 0xe88;	// LAO LETTER CO
-	c = 0xe94;		// from LAO LETTER DO
-	while (c <= 0xe97)	// ..to LAO LETTER THO TAM
+	c = 0xe86;		// from LAO LETTER PALI GHA
+	while (c <= 0xe8a)	// ..to LAO LETTER SO TAM
 		charset[i++] = c++;
-	c = 0xe99;		// from LAO LETTER NO
-	while (c <= 0xe9f)	// ..to LAO LETTER FO SUNG
+	c = 0xe8c;		// from LAO LETTER PALI JHA
+	while (c <= 0xea3)	// ..to LAO LETTER LO LING
 		charset[i++] = c++;
-	charset[i++] = 0xea1;	// LAO LETTER MO
-	charset[i++] = 0xea3;	// LAO LETTER LO LING
-	charset[i++] = 0xeaa;	// LAO LETTER SO SUNG
-	charset[i++] = 0xeab;	// LAO LETTER HO SUNG
-	c = 0xead;		// from LAO LETTER O
-	while (c <= 0xeb9)	// ..to LAO VOWEL SIGN UU
+	c = 0xea7;		// from LAO LETTER WO
+	while (c <= 0xebd)	// ..to LAO SEMIVOWEL SIGN NYO
 		charset[i++] = c++;
-	charset[i++] = 0xebb;	// LAO VOWEL SIGN MAI KON
-	charset[i++] = 0xebd;	// LAO SEMIVOWEL SIGN NYO
 	c = 0xec0;		// from LAO VOWEL SIGN E
 	while (c <= 0xec4)	// ..to LAO VOWEL SIGN AI
 		charset[i++] = c++;
@@ -710,7 +704,7 @@ void init()
 		charset[i++] = c++;
 // 1AB0..1AFF; Combining Diacritical Marks Extended
 	c = 0x1ab0;		// from COMBINING DOUBLED CIRCUMFLEX ACCENT
-	while (c <= 0x1abe)	// ..to COMBINING PARENTHESES OVERLAY
+	while (c <= 0x1ac0)	// ..to COMBINING LATIN SMALL LETTER TURNED W BELOW
 		charset[i++] = c++;
 // 1B00..1B7F; Balinese
 	c = 0x1b00;		// from BALINESE SIGN ULU RICEM
@@ -759,7 +753,7 @@ void init()
 		charset[i++] = c++;
 // 1CD0..1CFF; Vedic Extensions
 	c = 0x1cd0;		// from VEDIC TONE KARSHANA
-	while (c <= 0x1cf9)	// ..to VEDIC TONE DOUBLE RING ABOVE
+	while (c <= 0x1cfa)	// ..to VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
 		charset[i++] = c++;
 // 1D00..1D7F; Phonetic Extensions
 	c = 0x1d00;		// from LATIN LETTER SMALL CAPITAL A
@@ -926,11 +920,8 @@ void init()
 	c = 0x2b76;		// from NORTH WEST TRIANGLE-HEADED ARROW TO BAR
 	while (c <= 0x2b95)	// ..to RIGHTWARDS BLACK ARROW
 		charset[i++] = c++;
-	c = 0x2b98;		// from THREE-D TOP-LIGHTED LEFTWARDS EQUILATERAL ARROWHEAD
-	while (c <= 0x2bc8)	// ..to BLACK MEDIUM RIGHT-POINTING TRIANGLE CENTRED
-		charset[i++] = c++;
-	c = 0x2bca;		// from TOP HALF BLACK CIRCLE
-	while (c <= 0x2bfe)	// ..to REVERSED RIGHT ANGLE
+	c = 0x2b97;		// from SYMBOL FOR TYPE A ELECTRONICS
+	while (c <= 0x2bff)	// ..to HELLSCHREIBER PAUSE SYMBOL
 		charset[i++] = c++;
 // 2C00..2C5F; Glagolitic
 	c = 0x2c00;		// from GLAGOLITIC CAPITAL LETTER AZU
@@ -998,7 +989,7 @@ void init()
 		charset[i++] = c++;
 // 2E00..2E7F; Supplemental Punctuation
 	c = 0x2e00;		// from RIGHT ANGLE SUBSTITUTION MARKER
-	while (c <= 0x2e4e)	// ..to PUNCTUS ELEVATUS MARK
+	while (c <= 0x2e52)	// ..to TIRONIAN SIGN CAPITAL ET
 		charset[i++] = c++;
 // 2E80..2EFF; CJK Radicals Supplement
 	c = 0x2e80;		// from CJK RADICAL REPEAT
@@ -1044,7 +1035,7 @@ void init()
 		charset[i++] = c++;
 // 31A0..31BF; Bopomofo Extended
 	c = 0x31a0;		// from BOPOMOFO LETTER BU
-	while (c <= 0x31ba)	// ..to BOPOMOFO LETTER ZY
+	while (c <= 0x31bf)	// ..to BOPOMOFO LETTER AH
 		charset[i++] = c++;
 // 31C0..31EF; CJK Strokes
 	c = 0x31c0;		// from CJK STROKE T
@@ -1059,7 +1050,7 @@ void init()
 	while (c <= 0x321e)	// ..to PARENTHESIZED KOREAN CHARACTER O HU
 		charset[i++] = c++;
 	c = 0x3220;		// from PARENTHESIZED IDEOGRAPH ONE
-	while (c <= 0x32fe)	// ..to CIRCLED KATAKANA WO
+	while (c <= 0x32ff)	// ..to SQUARE ERA NAME REIWA
 		charset[i++] = c++;
 // 3300..33FF; CJK Compatibility
 	c = 0x3300;		// from SQUARE APAATO
@@ -1067,7 +1058,7 @@ void init()
 		charset[i++] = c++;
 // 3400..4DBF; CJK Unified Ideographs Extension A
 	c = 0x3400;		// from <CJK Ideograph Extension A, First>
-	while (c <= 0x4db5)	// ..to <CJK Ideograph Extension A, Last>
+	while (c <= 0x4dbf)	// ..to <CJK Ideograph Extension A, Last>
 		charset[i++] = c++;
 // 4DC0..4DFF; Yijing Hexagram Symbols
 	c = 0x4dc0;		// from HEXAGRAM FOR THE CREATIVE HEAVEN
@@ -1075,7 +1066,7 @@ void init()
 		charset[i++] = c++;
 // 4E00..9FFF; CJK Unified Ideographs
 	c = 0x4e00;		// from <CJK Ideograph, First>
-	while (c <= 0x9fef)	// ..to <CJK Ideograph, Last>
+	while (c <= 0x9ffc)	// ..to <CJK Ideograph, Last>
 		charset[i++] = c++;
 // A000..A48F; Yi Syllables
 	c = 0xa000;		// from YI SYLLABLE IT
@@ -1107,14 +1098,17 @@ void init()
 		charset[i++] = c++;
 // A720..A7FF; Latin Extended-D
 	c = 0xa720;		// from MODIFIER LETTER STRESS AND HIGH TONE
-	while (c <= 0xa7b9)	// ..to LATIN SMALL LETTER U WITH STROKE
+	while (c <= 0xa7bf)	// ..to LATIN SMALL LETTER GLOTTAL U
 		charset[i++] = c++;
-	c = 0xa7f7;		// from LATIN EPIGRAPHIC LETTER SIDEWAYS I
+	c = 0xa7c2;		// from LATIN CAPITAL LETTER ANGLICANA W
+	while (c <= 0xa7ca)	// ..to LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+		charset[i++] = c++;
+	c = 0xa7f5;		// from LATIN CAPITAL LETTER REVERSED HALF H
 	while (c <= 0xa7ff)	// ..to LATIN EPIGRAPHIC LETTER ARCHAIC M
 		charset[i++] = c++;
 // A800..A82F; Syloti Nagri
 	c = 0xa800;		// from SYLOTI NAGRI LETTER A
-	while (c <= 0xa82b)	// ..to SYLOTI NAGRI POETRY MARK-4
+	while (c <= 0xa82c)	// ..to SYLOTI NAGRI SIGN ALTERNATE HASANTA
 		charset[i++] = c++;
 // A830..A83F; Common Indic Number Forms
 	c = 0xa830;		// from NORTH INDIC FRACTION ONE QUARTER
@@ -1207,7 +1201,7 @@ void init()
 		charset[i++] = c++;
 // AB30..AB6F; Latin Extended-E
 	c = 0xab30;		// from LATIN SMALL LETTER BARRED ALPHA
-	while (c <= 0xab65)	// ..to GREEK LETTER SMALL CAPITAL OMEGA
+	while (c <= 0xab6b)	// ..to MODIFIER LETTER RIGHT TACK
 		charset[i++] = c++;
 // AB70..ABBF; Cherokee Supplement
 	c = 0xab70;		// from CHEROKEE SMALL LETTER A

--- a/data/jtr/dumb32.conf
+++ b/data/jtr/dumb32.conf
@@ -1,11 +1,11 @@
-# This  software is Copyright (c) 2012-2018 magnum, and it is hereby
+# This  software is Copyright (c) 2012-2020 magnum, and it is hereby
 # released to the general public under the following terms:
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted.
 #
 # Generic implementation of "dumb" exhaustive search of FULL Unicode.
-# Default is to try *all* allocated characters in Unicode v11 (there's
-# 137,046 of them). Even if a fast format can exhaust two characters in one
+# Default is to try *all* allocated characters in Unicode v13 (there's
+# 143,532 of them). Even if a fast format can exhaust two characters in one
 # hour, three characters would take 12 years...
 #
 # Note that these modes will handle --max-len differently than normal: They
@@ -17,12 +17,17 @@
 # format will be up to four bytes (two 16-bit words) due to use of surrogates
 # for characters above U+FFFF. This means a format which normally handles up
 # to 27 characters may be limited to only 13 characters, worst case.
+#
+# Note that the (newer) cracking mode --subsets=full-unicode is way faster than
+# this external mode, although not as easy to adapt to smaller portions of the
+# Unicode space.  See doc/SUBSETS
+
 [List.External:Dumb32]
 int maxlength;            // Maximum password length to try
 int last;                 // Last character position, zero-based
 int lastid;               // Character index in the last position
 int id[0x7f];             // Current character indices for other positions
-int charset[0x22000], c0; // Characters
+int charset[0x24000], c0; // Characters
 
 void init()
 {
@@ -168,7 +173,7 @@ void init()
 	while (c <= 0x8b4)	// ..to ARABIC LETTER KAF WITH DOT BELOW
 		charset[i++] = c++;
 	c = 0x8b6;		// from ARABIC LETTER BEH WITH SMALL MEEM ABOVE
-	while (c <= 0x8bd)	// ..to ARABIC LETTER AFRICAN NOON
+	while (c <= 0x8c7)	// ..to ARABIC LETTER LAM WITH SMALL ARABIC LETTER TAH ABOVE
 		charset[i++] = c++;
 	c = 0x8d3;		// from ARABIC SMALL LOW WAW
 	while (c <= 0x8ff)	// ..to ARABIC MARK SIDEWAYS NOON GHUNNA
@@ -305,7 +310,7 @@ void init()
 	charset[i++] = 0xb48;	// ORIYA VOWEL SIGN AI
 	charset[i++] = 0xb4b;	// ORIYA VOWEL SIGN O
 	charset[i++] = 0xb4d;	// ORIYA SIGN VIRAMA
-	charset[i++] = 0xb56;	// ORIYA AI LENGTH MARK
+	charset[i++] = 0xb55;	// ORIYA SIGN OVERLINE
 	charset[i++] = 0xb57;	// ORIYA AU LENGTH MARK
 	charset[i++] = 0xb5c;	// ORIYA LETTER RRA
 	charset[i++] = 0xb5d;	// ORIYA LETTER RHA
@@ -378,7 +383,7 @@ void init()
 	c = 0xc66;		// from TELUGU DIGIT ZERO
 	while (c <= 0xc6f)	// ..to TELUGU DIGIT NINE
 		charset[i++] = c++;
-	c = 0xc78;		// from TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR
+	c = 0xc77;		// from TELUGU SIGN SIDDHAM
 	while (c <= 0xc7f)	// ..to TELUGU SIGN TUUMU
 		charset[i++] = c++;
 // 0C80..0CFF; Kannada
@@ -416,9 +421,6 @@ void init()
 	charset[i++] = 0xcf2;	// KANNADA SIGN UPADHMANIYA
 // 0D00..0D7F; Malayalam
 	c = 0xd00;		// from MALAYALAM SIGN COMBINING ANUSVARA ABOVE
-	while (c <= 0xd03)	// ..to MALAYALAM SIGN VISARGA
-		charset[i++] = c++;
-	c = 0xd05;		// from MALAYALAM LETTER A
 	while (c <= 0xd0c)	// ..to MALAYALAM LETTER VOCALIC L
 		charset[i++] = c++;
 	charset[i++] = 0xd0e;	// MALAYALAM LETTER E
@@ -438,7 +440,7 @@ void init()
 	while (c <= 0xd7f)	// ..to MALAYALAM LETTER CHILLU K
 		charset[i++] = c++;
 // 0D80..0DFF; Sinhala
-	charset[i++] = 0xd82;	// SINHALA SIGN ANUSVARAYA
+	charset[i++] = 0xd81;	// SINHALA SIGN CANDRABINDU
 	charset[i++] = 0xd83;	// SINHALA SIGN VISARGAYA
 	c = 0xd85;		// from SINHALA LETTER AYANNA
 	while (c <= 0xd96)	// ..to SINHALA LETTER AUYANNA
@@ -473,23 +475,15 @@ void init()
 // 0E80..0EFF; Lao
 	charset[i++] = 0xe81;	// LAO LETTER KO
 	charset[i++] = 0xe82;	// LAO LETTER KHO SUNG
-	charset[i++] = 0xe87;	// LAO LETTER NGO
-	charset[i++] = 0xe88;	// LAO LETTER CO
-	c = 0xe94;		// from LAO LETTER DO
-	while (c <= 0xe97)	// ..to LAO LETTER THO TAM
+	c = 0xe86;		// from LAO LETTER PALI GHA
+	while (c <= 0xe8a)	// ..to LAO LETTER SO TAM
 		charset[i++] = c++;
-	c = 0xe99;		// from LAO LETTER NO
-	while (c <= 0xe9f)	// ..to LAO LETTER FO SUNG
+	c = 0xe8c;		// from LAO LETTER PALI JHA
+	while (c <= 0xea3)	// ..to LAO LETTER LO LING
 		charset[i++] = c++;
-	charset[i++] = 0xea1;	// LAO LETTER MO
-	charset[i++] = 0xea3;	// LAO LETTER LO LING
-	charset[i++] = 0xeaa;	// LAO LETTER SO SUNG
-	charset[i++] = 0xeab;	// LAO LETTER HO SUNG
-	c = 0xead;		// from LAO LETTER O
-	while (c <= 0xeb9)	// ..to LAO VOWEL SIGN UU
+	c = 0xea7;		// from LAO LETTER WO
+	while (c <= 0xebd)	// ..to LAO SEMIVOWEL SIGN NYO
 		charset[i++] = c++;
-	charset[i++] = 0xebb;	// LAO VOWEL SIGN MAI KON
-	charset[i++] = 0xebd;	// LAO SEMIVOWEL SIGN NYO
 	c = 0xec0;		// from LAO VOWEL SIGN E
 	while (c <= 0xec4)	// ..to LAO VOWEL SIGN AI
 		charset[i++] = c++;
@@ -715,7 +709,7 @@ void init()
 		charset[i++] = c++;
 // 1AB0..1AFF; Combining Diacritical Marks Extended
 	c = 0x1ab0;		// from COMBINING DOUBLED CIRCUMFLEX ACCENT
-	while (c <= 0x1abe)	// ..to COMBINING PARENTHESES OVERLAY
+	while (c <= 0x1ac0)	// ..to COMBINING LATIN SMALL LETTER TURNED W BELOW
 		charset[i++] = c++;
 // 1B00..1B7F; Balinese
 	c = 0x1b00;		// from BALINESE SIGN ULU RICEM
@@ -764,7 +758,7 @@ void init()
 		charset[i++] = c++;
 // 1CD0..1CFF; Vedic Extensions
 	c = 0x1cd0;		// from VEDIC TONE KARSHANA
-	while (c <= 0x1cf9)	// ..to VEDIC TONE DOUBLE RING ABOVE
+	while (c <= 0x1cfa)	// ..to VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
 		charset[i++] = c++;
 // 1D00..1D7F; Phonetic Extensions
 	c = 0x1d00;		// from LATIN LETTER SMALL CAPITAL A
@@ -931,11 +925,8 @@ void init()
 	c = 0x2b76;		// from NORTH WEST TRIANGLE-HEADED ARROW TO BAR
 	while (c <= 0x2b95)	// ..to RIGHTWARDS BLACK ARROW
 		charset[i++] = c++;
-	c = 0x2b98;		// from THREE-D TOP-LIGHTED LEFTWARDS EQUILATERAL ARROWHEAD
-	while (c <= 0x2bc8)	// ..to BLACK MEDIUM RIGHT-POINTING TRIANGLE CENTRED
-		charset[i++] = c++;
-	c = 0x2bca;		// from TOP HALF BLACK CIRCLE
-	while (c <= 0x2bfe)	// ..to REVERSED RIGHT ANGLE
+	c = 0x2b97;		// from SYMBOL FOR TYPE A ELECTRONICS
+	while (c <= 0x2bff)	// ..to HELLSCHREIBER PAUSE SYMBOL
 		charset[i++] = c++;
 // 2C00..2C5F; Glagolitic
 	c = 0x2c00;		// from GLAGOLITIC CAPITAL LETTER AZU
@@ -1003,7 +994,7 @@ void init()
 		charset[i++] = c++;
 // 2E00..2E7F; Supplemental Punctuation
 	c = 0x2e00;		// from RIGHT ANGLE SUBSTITUTION MARKER
-	while (c <= 0x2e4e)	// ..to PUNCTUS ELEVATUS MARK
+	while (c <= 0x2e52)	// ..to TIRONIAN SIGN CAPITAL ET
 		charset[i++] = c++;
 // 2E80..2EFF; CJK Radicals Supplement
 	c = 0x2e80;		// from CJK RADICAL REPEAT
@@ -1049,7 +1040,7 @@ void init()
 		charset[i++] = c++;
 // 31A0..31BF; Bopomofo Extended
 	c = 0x31a0;		// from BOPOMOFO LETTER BU
-	while (c <= 0x31ba)	// ..to BOPOMOFO LETTER ZY
+	while (c <= 0x31bf)	// ..to BOPOMOFO LETTER AH
 		charset[i++] = c++;
 // 31C0..31EF; CJK Strokes
 	c = 0x31c0;		// from CJK STROKE T
@@ -1064,7 +1055,7 @@ void init()
 	while (c <= 0x321e)	// ..to PARENTHESIZED KOREAN CHARACTER O HU
 		charset[i++] = c++;
 	c = 0x3220;		// from PARENTHESIZED IDEOGRAPH ONE
-	while (c <= 0x32fe)	// ..to CIRCLED KATAKANA WO
+	while (c <= 0x32ff)	// ..to SQUARE ERA NAME REIWA
 		charset[i++] = c++;
 // 3300..33FF; CJK Compatibility
 	c = 0x3300;		// from SQUARE APAATO
@@ -1072,7 +1063,7 @@ void init()
 		charset[i++] = c++;
 // 3400..4DBF; CJK Unified Ideographs Extension A
 	c = 0x3400;		// from <CJK Ideograph Extension A, First>
-	while (c <= 0x4db5)	// ..to <CJK Ideograph Extension A, Last>
+	while (c <= 0x4dbf)	// ..to <CJK Ideograph Extension A, Last>
 		charset[i++] = c++;
 // 4DC0..4DFF; Yijing Hexagram Symbols
 	c = 0x4dc0;		// from HEXAGRAM FOR THE CREATIVE HEAVEN
@@ -1080,7 +1071,7 @@ void init()
 		charset[i++] = c++;
 // 4E00..9FFF; CJK Unified Ideographs
 	c = 0x4e00;		// from <CJK Ideograph, First>
-	while (c <= 0x9fef)	// ..to <CJK Ideograph, Last>
+	while (c <= 0x9ffc)	// ..to <CJK Ideograph, Last>
 		charset[i++] = c++;
 // A000..A48F; Yi Syllables
 	c = 0xa000;		// from YI SYLLABLE IT
@@ -1112,14 +1103,17 @@ void init()
 		charset[i++] = c++;
 // A720..A7FF; Latin Extended-D
 	c = 0xa720;		// from MODIFIER LETTER STRESS AND HIGH TONE
-	while (c <= 0xa7b9)	// ..to LATIN SMALL LETTER U WITH STROKE
+	while (c <= 0xa7bf)	// ..to LATIN SMALL LETTER GLOTTAL U
 		charset[i++] = c++;
-	c = 0xa7f7;		// from LATIN EPIGRAPHIC LETTER SIDEWAYS I
+	c = 0xa7c2;		// from LATIN CAPITAL LETTER ANGLICANA W
+	while (c <= 0xa7ca)	// ..to LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+		charset[i++] = c++;
+	c = 0xa7f5;		// from LATIN CAPITAL LETTER REVERSED HALF H
 	while (c <= 0xa7ff)	// ..to LATIN EPIGRAPHIC LETTER ARCHAIC M
 		charset[i++] = c++;
 // A800..A82F; Syloti Nagri
 	c = 0xa800;		// from SYLOTI NAGRI LETTER A
-	while (c <= 0xa82b)	// ..to SYLOTI NAGRI POETRY MARK-4
+	while (c <= 0xa82c)	// ..to SYLOTI NAGRI SIGN ALTERNATE HASANTA
 		charset[i++] = c++;
 // A830..A83F; Common Indic Number Forms
 	c = 0xa830;		// from NORTH INDIC FRACTION ONE QUARTER
@@ -1212,7 +1206,7 @@ void init()
 		charset[i++] = c++;
 // AB30..AB6F; Latin Extended-E
 	c = 0xab30;		// from LATIN SMALL LETTER BARRED ALPHA
-	while (c <= 0xab65)	// ..to GREEK LETTER SMALL CAPITAL OMEGA
+	while (c <= 0xab6b)	// ..to MODIFIER LETTER RIGHT TACK
 		charset[i++] = c++;
 // AB70..ABBF; Cherokee Supplement
 	c = 0xab70;		// from CHEROKEE SMALL LETTER A
@@ -1378,7 +1372,7 @@ void init()
 		charset[i++] = c++;
 // 10190..101CF; Ancient Symbols
 	c = 0x10190;		// from ROMAN SEXTANS SIGN
-	while (c <= 0x1019b)	// ..to ROMAN CENTURIAL SIGN
+	while (c <= 0x1019c)	// ..to ASCIA SYMBOL
 		charset[i++] = c++;
 	charset[i++] = 0x101a0;	// GREEK SYMBOL TAU RHO
 // 101D0..101FF; Phaistos Disc
@@ -1620,6 +1614,14 @@ void init()
 	c = 0x10e60;		// from RUMI DIGIT ONE
 	while (c <= 0x10e7e)	// ..to RUMI FRACTION TWO THIRDS
 		charset[i++] = c++;
+// 10E80..10EBF; Yezidi
+	c = 0x10e80;		// from YEZIDI LETTER ELIF
+	while (c <= 0x10ea9)	// ..to YEZIDI LETTER ET
+		charset[i++] = c++;
+	charset[i++] = 0x10eab;	// YEZIDI COMBINING HAMZA MARK
+	charset[i++] = 0x10ead;	// YEZIDI HYPHENATION MARK
+	charset[i++] = 0x10eb0;	// YEZIDI LETTER LAM WITH DOT ABOVE
+	charset[i++] = 0x10eb1;	// YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
 // 10F00..10F2F; Old Sogdian
 	c = 0x10f00;		// from OLD SOGDIAN LETTER ALEPH
 	while (c <= 0x10f27)	// ..to OLD SOGDIAN LIGATURE AYIN-DALETH
@@ -1627,6 +1629,14 @@ void init()
 // 10F30..10F6F; Sogdian
 	c = 0x10f30;		// from SOGDIAN LETTER ALEPH
 	while (c <= 0x10f59)	// ..to SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
+		charset[i++] = c++;
+// 10FB0..10FDF; Chorasmian
+	c = 0x10fb0;		// from CHORASMIAN LETTER ALEPH
+	while (c <= 0x10fcb)	// ..to CHORASMIAN NUMBER ONE HUNDRED
+		charset[i++] = c++;
+// 10FE0..10FFF; Elymaic
+	c = 0x10fe0;		// from ELYMAIC LETTER ALEPH
+	while (c <= 0x10ff6)	// ..to ELYMAIC LIGATURE ZAYIN-YODH
 		charset[i++] = c++;
 // 11000..1107F; Brahmi
 	c = 0x11000;		// from BRAHMI SIGN CANDRABINDU
@@ -1653,7 +1663,7 @@ void init()
 	while (c <= 0x11134)	// ..to CHAKMA MAAYYAA
 		charset[i++] = c++;
 	c = 0x11136;		// from CHAKMA DIGIT ZERO
-	while (c <= 0x11146)	// ..to CHAKMA VOWEL SIGN EI
+	while (c <= 0x11147)	// ..to CHAKMA LETTER VAA
 		charset[i++] = c++;
 // 11150..1117F; Mahajani
 	c = 0x11150;		// from MAHAJANI LETTER A
@@ -1661,9 +1671,6 @@ void init()
 		charset[i++] = c++;
 // 11180..111DF; Sharada
 	c = 0x11180;		// from SHARADA SIGN CANDRABINDU
-	while (c <= 0x111cd)	// ..to SHARADA SUTRA MARK
-		charset[i++] = c++;
-	c = 0x111d0;		// from SHARADA DIGIT ZERO
 	while (c <= 0x111df)	// ..to SHARADA SECTION MARK-2
 		charset[i++] = c++;
 // 111E0..111FF; Sinhala Archaic Numbers
@@ -1735,10 +1742,11 @@ void init()
 		charset[i++] = c++;
 // 11400..1147F; Newa
 	c = 0x11400;		// from NEWA LETTER A
-	while (c <= 0x11459)	// ..to NEWA DIGIT NINE
+	while (c <= 0x1145b)	// ..to NEWA PLACEHOLDER MARK
 		charset[i++] = c++;
-	charset[i++] = 0x1145d;	// NEWA INSERTION SIGN
-	charset[i++] = 0x1145e;	// NEWA SANDHI MARK
+	c = 0x1145d;		// from NEWA INSERTION SIGN
+	while (c <= 0x11461)	// ..to NEWA SIGN UPADHMANIYA
+		charset[i++] = c++;
 // 11480..114DF; Tirhuta
 	c = 0x11480;		// from TIRHUTA ANJI
 	while (c <= 0x114c7)	// ..to TIRHUTA OM
@@ -1766,7 +1774,7 @@ void init()
 		charset[i++] = c++;
 // 11680..116CF; Takri
 	c = 0x11680;		// from TAKRI LETTER A
-	while (c <= 0x116b7)	// ..to TAKRI SIGN NUKTA
+	while (c <= 0x116b8)	// ..to TAKRI LETTER ARCHAIC KHA
 		charset[i++] = c++;
 	c = 0x116c0;		// from TAKRI DIGIT ZERO
 	while (c <= 0x116c9)	// ..to TAKRI DIGIT NINE
@@ -1790,15 +1798,42 @@ void init()
 	while (c <= 0x118f2)	// ..to WARANG CITI NUMBER NINETY
 		charset[i++] = c++;
 	charset[i++] = 0x118ff;	// WARANG CITI OM
+// 11900..1195F; Dives Akuru
+	c = 0x11900;		// from DIVES AKURU LETTER A
+	while (c <= 0x11906)	// ..to DIVES AKURU LETTER E
+		charset[i++] = c++;
+	c = 0x1190c;		// from DIVES AKURU LETTER KA
+	while (c <= 0x11913)	// ..to DIVES AKURU LETTER JA
+		charset[i++] = c++;
+	charset[i++] = 0x11915;	// DIVES AKURU LETTER NYA
+	charset[i++] = 0x11916;	// DIVES AKURU LETTER TTA
+	c = 0x11918;		// from DIVES AKURU LETTER DDA
+	while (c <= 0x11935)	// ..to DIVES AKURU VOWEL SIGN E
+		charset[i++] = c++;
+	charset[i++] = 0x11937;	// DIVES AKURU VOWEL SIGN AI
+	charset[i++] = 0x11938;	// DIVES AKURU VOWEL SIGN O
+	c = 0x1193b;		// from DIVES AKURU SIGN ANUSVARA
+	while (c <= 0x11946)	// ..to DIVES AKURU END OF TEXT MARK
+		charset[i++] = c++;
+	c = 0x11950;		// from DIVES AKURU DIGIT ZERO
+	while (c <= 0x11959)	// ..to DIVES AKURU DIGIT NINE
+		charset[i++] = c++;
+// 119A0..119FF; Nandinagari
+	c = 0x119a0;		// from NANDINAGARI LETTER A
+	while (c <= 0x119a7)	// ..to NANDINAGARI LETTER VOCALIC RR
+		charset[i++] = c++;
+	c = 0x119aa;		// from NANDINAGARI LETTER E
+	while (c <= 0x119d7)	// ..to NANDINAGARI VOWEL SIGN VOCALIC RR
+		charset[i++] = c++;
+	c = 0x119da;		// from NANDINAGARI VOWEL SIGN E
+	while (c <= 0x119e4)	// ..to NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+		charset[i++] = c++;
 // 11A00..11A4F; Zanabazar Square
 	c = 0x11a00;		// from ZANABAZAR SQUARE LETTER A
 	while (c <= 0x11a47)	// ..to ZANABAZAR SQUARE SUBJOINER
 		charset[i++] = c++;
 // 11A50..11AAF; Soyombo
 	c = 0x11a50;		// from SOYOMBO LETTER A
-	while (c <= 0x11a83)	// ..to SOYOMBO LETTER KSSA
-		charset[i++] = c++;
-	c = 0x11a86;		// from SOYOMBO CLUSTER-INITIAL LETTER RA
 	while (c <= 0x11aa2)	// ..to SOYOMBO TERMINAL MARK-2
 		charset[i++] = c++;
 // 11AC0..11AFF; Pau Cin Hau
@@ -1866,6 +1901,13 @@ void init()
 	c = 0x11ee0;		// from MAKASAR LETTER KA
 	while (c <= 0x11ef8)	// ..to MAKASAR END OF SECTION
 		charset[i++] = c++;
+// 11FB0..11FBF; Lisu Supplement
+	charset[i++] = 0x11fb0;	// LISU LETTER YHA
+// 11FC0..11FFF; Tamil Supplement
+	c = 0x11fc0;		// from TAMIL FRACTION ONE THREE-HUNDRED-AND-TWENTIETH
+	while (c <= 0x11ff1)	// ..to TAMIL SIGN VAKAIYARAA
+		charset[i++] = c++;
+	charset[i++] = 0x11fff;	// TAMIL PUNCTUATION END OF TEXT
 // 12000..123FF; Cuneiform
 	c = 0x12000;		// from CUNEIFORM SIGN A
 	while (c <= 0x12399)	// ..to CUNEIFORM SIGN U U
@@ -1884,6 +1926,10 @@ void init()
 // 13000..1342F; Egyptian Hieroglyphs
 	c = 0x13000;		// from EGYPTIAN HIEROGLYPH A001
 	while (c <= 0x1342e)	// ..to EGYPTIAN HIEROGLYPH AA032
+		charset[i++] = c++;
+// 13430..1343F; Egyptian Hieroglyph Format Controls
+	c = 0x13430;		// from EGYPTIAN HIEROGLYPH VERTICAL JOINER
+	while (c <= 0x13438)	// ..to EGYPTIAN HIEROGLYPH END SEGMENT
 		charset[i++] = c++;
 // 14400..1467F; Anatolian Hieroglyphs
 	c = 0x14400;		// from ANATOLIAN HIEROGLYPH A001
@@ -1931,24 +1977,35 @@ void init()
 		charset[i++] = c++;
 // 16F00..16F9F; Miao
 	c = 0x16f00;		// from MIAO LETTER PA
-	while (c <= 0x16f44)	// ..to MIAO LETTER HHA
+	while (c <= 0x16f4a)	// ..to MIAO LETTER RTE
 		charset[i++] = c++;
-	c = 0x16f50;		// from MIAO LETTER NASALIZATION
-	while (c <= 0x16f7e)	// ..to MIAO VOWEL SIGN NG
+	c = 0x16f4f;		// from MIAO SIGN CONSONANT MODIFIER BAR
+	while (c <= 0x16f87)	// ..to MIAO VOWEL SIGN UI
 		charset[i++] = c++;
 	c = 0x16f8f;		// from MIAO TONE RIGHT
 	while (c <= 0x16f9f)	// ..to MIAO LETTER REFORMED TONE-8
 		charset[i++] = c++;
 // 16FE0..16FFF; Ideographic Symbols and Punctuation
-	charset[i++] = 0x16fe0;	// TANGUT ITERATION MARK
-	charset[i++] = 0x16fe1;	// NUSHU ITERATION MARK
+	c = 0x16fe0;		// from TANGUT ITERATION MARK
+	while (c <= 0x16fe4)	// ..to KHITAN SMALL SCRIPT FILLER
+		charset[i++] = c++;
+	charset[i++] = 0x16ff0;	// VIETNAMESE ALTERNATE READING MARK CA
+	charset[i++] = 0x16ff1;	// VIETNAMESE ALTERNATE READING MARK NHAY
 // 17000..187FF; Tangut
 	c = 0x17000;		// from <Tangut Ideograph, First>
-	while (c <= 0x187f1)	// ..to <Tangut Ideograph, Last>
+	while (c <= 0x187f7)	// ..to <Tangut Ideograph, Last>
 		charset[i++] = c++;
 // 18800..18AFF; Tangut Components
 	c = 0x18800;		// from TANGUT COMPONENT-001
-	while (c <= 0x18af2)	// ..to TANGUT COMPONENT-755
+	while (c <= 0x18aff)	// ..to TANGUT COMPONENT-768
+		charset[i++] = c++;
+// 18B00..18CFF; Khitan Small Script
+	c = 0x18b00;		// from KHITAN SMALL SCRIPT CHARACTER-18B00
+	while (c <= 0x18cd5)	// ..to KHITAN SMALL SCRIPT CHARACTER-18CD5
+		charset[i++] = c++;
+// 18D00..18D8F; Tangut Supplement
+	c = 0x18d00;		// from <Tangut Ideograph Supplement, First>
+	while (c <= 0x18d08)	// ..to <Tangut Ideograph Supplement, Last>
 		charset[i++] = c++;
 // 1B000..1B0FF; Kana Supplement
 	c = 0x1b000;		// from KATAKANA LETTER ARCHAIC E
@@ -1957,6 +2014,12 @@ void init()
 // 1B100..1B12F; Kana Extended-A
 	c = 0x1b100;		// from HENTAIGANA LETTER RE-3
 	while (c <= 0x1b11e)	// ..to HENTAIGANA LETTER N-MU-MO-2
+		charset[i++] = c++;
+// 1B130..1B16F; Small Kana Extension
+	charset[i++] = 0x1b150;	// HIRAGANA LETTER SMALL WI
+	charset[i++] = 0x1b152;	// HIRAGANA LETTER SMALL WO
+	c = 0x1b164;		// from KATAKANA LETTER SMALL WI
+	while (c <= 0x1b167)	// ..to KATAKANA LETTER SMALL N
 		charset[i++] = c++;
 // 1B170..1B2FF; Nushu
 	c = 0x1b170;		// from NUSHU CHARACTER-1B170
@@ -2087,6 +2150,23 @@ void init()
 	c = 0x1e026;		// from COMBINING GLAGOLITIC LETTER YO
 	while (c <= 0x1e02a)	// ..to COMBINING GLAGOLITIC LETTER FITA
 		charset[i++] = c++;
+// 1E100..1E14F; Nyiakeng Puachue Hmong
+	c = 0x1e100;		// from NYIAKENG PUACHUE HMONG LETTER MA
+	while (c <= 0x1e12c)	// ..to NYIAKENG PUACHUE HMONG LETTER W
+		charset[i++] = c++;
+	c = 0x1e130;		// from NYIAKENG PUACHUE HMONG TONE-B
+	while (c <= 0x1e13d)	// ..to NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+		charset[i++] = c++;
+	c = 0x1e140;		// from NYIAKENG PUACHUE HMONG DIGIT ZERO
+	while (c <= 0x1e149)	// ..to NYIAKENG PUACHUE HMONG DIGIT NINE
+		charset[i++] = c++;
+	charset[i++] = 0x1e14e;	// NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+	charset[i++] = 0x1e14f;	// NYIAKENG PUACHUE HMONG CIRCLED CA
+// 1E2C0..1E2FF; Wancho
+	c = 0x1e2c0;		// from WANCHO LETTER AA
+	while (c <= 0x1e2f9)	// ..to WANCHO DIGIT NINE
+		charset[i++] = c++;
+	charset[i++] = 0x1e2ff;	// WANCHO NGUN SIGN
 // 1E800..1E8DF; Mende Kikakui
 	c = 0x1e800;		// from MENDE KIKAKUI SYLLABLE M001 KI
 	while (c <= 0x1e8c4)	// ..to MENDE KIKAKUI SYLLABLE M060 NYON
@@ -2096,7 +2176,7 @@ void init()
 		charset[i++] = c++;
 // 1E900..1E95F; Adlam
 	c = 0x1e900;		// from ADLAM CAPITAL LETTER ALIF
-	while (c <= 0x1e94a)	// ..to ADLAM NUKTA
+	while (c <= 0x1e94b)	// ..to ADLAM NASALIZATION MARK
 		charset[i++] = c++;
 	c = 0x1e950;		// from ADLAM DIGIT ZERO
 	while (c <= 0x1e959)	// ..to ADLAM DIGIT NINE
@@ -2106,6 +2186,10 @@ void init()
 // 1EC70..1ECBF; Indic Siyaq Numbers
 	c = 0x1ec71;		// from INDIC SIYAQ NUMBER ONE
 	while (c <= 0x1ecb4)	// ..to INDIC SIYAQ ALTERNATE LAKH MARK
+		charset[i++] = c++;
+// 1ED00..1ED4F; Ottoman Siyaq Numbers
+	c = 0x1ed01;		// from OTTOMAN SIYAQ NUMBER ONE
+	while (c <= 0x1ed3d)	// ..to OTTOMAN SIYAQ FRACTION ONE SIXTH
 		charset[i++] = c++;
 // 1EE00..1EEFF; Arabic Mathematical Alphabetic Symbols
 	c = 0x1ee00;		// from ARABIC MATHEMATICAL ALEF
@@ -2179,13 +2263,7 @@ void init()
 		charset[i++] = c++;
 // 1F100..1F1FF; Enclosed Alphanumeric Supplement
 	c = 0x1f100;		// from DIGIT ZERO FULL STOP
-	while (c <= 0x1f10c)	// ..to DINGBAT NEGATIVE CIRCLED SANS-SERIF DIGIT ZERO
-		charset[i++] = c++;
-	c = 0x1f110;		// from PARENTHESIZED LATIN CAPITAL LETTER A
-	while (c <= 0x1f16b)	// ..to RAISED MD SIGN
-		charset[i++] = c++;
-	c = 0x1f170;		// from NEGATIVE SQUARED LATIN CAPITAL LETTER A
-	while (c <= 0x1f1ac)	// ..to SQUARED VOD
+	while (c <= 0x1f1ad)	// ..to MASK WORK SYMBOL
 		charset[i++] = c++;
 	c = 0x1f1e6;		// from REGIONAL INDICATOR SYMBOL LETTER A
 	while (c <= 0x1f1ff)	// ..to REGIONAL INDICATOR SYMBOL LETTER Z
@@ -2218,13 +2296,13 @@ void init()
 		charset[i++] = c++;
 // 1F680..1F6FF; Transport and Map Symbols
 	c = 0x1f680;		// from ROCKET
-	while (c <= 0x1f6d4)	// ..to PAGODA
+	while (c <= 0x1f6d7)	// ..to ELEVATOR
 		charset[i++] = c++;
 	c = 0x1f6e0;		// from HAMMER AND WRENCH
 	while (c <= 0x1f6ec)	// ..to AIRPLANE ARRIVING
 		charset[i++] = c++;
 	c = 0x1f6f0;		// from SATELLITE
-	while (c <= 0x1f6f9)	// ..to SKATEBOARD
+	while (c <= 0x1f6fc)	// ..to ROLLER SKATE
 		charset[i++] = c++;
 // 1F700..1F77F; Alchemical Symbols
 	c = 0x1f700;		// from ALCHEMICAL SYMBOL FOR QUINTESSENCE
@@ -2233,6 +2311,9 @@ void init()
 // 1F780..1F7FF; Geometric Shapes Extended
 	c = 0x1f780;		// from BLACK LEFT-POINTING ISOSCELES RIGHT TRIANGLE
 	while (c <= 0x1f7d8)	// ..to NEGATIVE CIRCLED SQUARE
+		charset[i++] = c++;
+	c = 0x1f7e0;		// from LARGE ORANGE CIRCLE
+	while (c <= 0x1f7eb)	// ..to LARGE BROWN SQUARE
 		charset[i++] = c++;
 // 1F800..1F8FF; Supplemental Arrows-C
 	c = 0x1f800;		// from LEFTWARDS ARROW WITH SMALL TRIANGLE ARROWHEAD
@@ -2250,37 +2331,58 @@ void init()
 	c = 0x1f890;		// from LEFTWARDS TRIANGLE ARROWHEAD
 	while (c <= 0x1f8ad)	// ..to WHITE ARROW SHAFT WIDTH TWO THIRDS
 		charset[i++] = c++;
+	charset[i++] = 0x1f8b0;	// ARROW POINTING UPWARDS THEN NORTH WEST
+	charset[i++] = 0x1f8b1;	// ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
 // 1F900..1F9FF; Supplemental Symbols and Pictographs
 	c = 0x1f900;		// from CIRCLED CROSS FORMEE WITH FOUR DOTS
-	while (c <= 0x1f90b)	// ..to DOWNWARD FACING NOTCHED HOOK WITH DOT
+	while (c <= 0x1f978)	// ..to DISGUISED FACE
 		charset[i++] = c++;
-	c = 0x1f910;		// from ZIPPER-MOUTH FACE
-	while (c <= 0x1f93e)	// ..to HANDBALL
+	c = 0x1f97a;		// from FACE WITH PLEADING EYES
+	while (c <= 0x1f9cb)	// ..to BUBBLE TEA
 		charset[i++] = c++;
-	c = 0x1f940;		// from WILTED FLOWER
-	while (c <= 0x1f970)	// ..to SMILING FACE WITH SMILING EYES AND THREE HEARTS
-		charset[i++] = c++;
-	c = 0x1f973;		// from FACE WITH PARTY HORN AND PARTY HAT
-	while (c <= 0x1f976)	// ..to FREEZING FACE
-		charset[i++] = c++;
-	c = 0x1f97c;		// from LAB COAT
-	while (c <= 0x1f9a2)	// ..to SWAN
-		charset[i++] = c++;
-	c = 0x1f9b0;		// from EMOJI COMPONENT RED HAIR
-	while (c <= 0x1f9b9)	// ..to SUPERVILLAIN
-		charset[i++] = c++;
-	charset[i++] = 0x1f9c0;	// CHEESE WEDGE
-	charset[i++] = 0x1f9c2;	// SALT SHAKER
-	c = 0x1f9d0;		// from FACE WITH MONOCLE
+	c = 0x1f9cd;		// from STANDING PERSON
 	while (c <= 0x1f9ff)	// ..to NAZAR AMULET
 		charset[i++] = c++;
 // 1FA00..1FA6F; Chess Symbols
+	c = 0x1fa00;		// from NEUTRAL CHESS KING
+	while (c <= 0x1fa53)	// ..to BLACK CHESS KNIGHT-BISHOP
+		charset[i++] = c++;
 	c = 0x1fa60;		// from XIANGQI RED GENERAL
 	while (c <= 0x1fa6d)	// ..to XIANGQI BLACK SOLDIER
 		charset[i++] = c++;
+// 1FA70..1FAFF; Symbols and Pictographs Extended-A
+	c = 0x1fa70;		// from BALLET SHOES
+	while (c <= 0x1fa74)	// ..to THONG SANDAL
+		charset[i++] = c++;
+	charset[i++] = 0x1fa78;	// DROP OF BLOOD
+	charset[i++] = 0x1fa7a;	// STETHOSCOPE
+	c = 0x1fa80;		// from YO-YO
+	while (c <= 0x1fa86)	// ..to NESTING DOLLS
+		charset[i++] = c++;
+	c = 0x1fa90;		// from RINGED PLANET
+	while (c <= 0x1faa8)	// ..to ROCK
+		charset[i++] = c++;
+	c = 0x1fab0;		// from FLY
+	while (c <= 0x1fab6)	// ..to FEATHER
+		charset[i++] = c++;
+	charset[i++] = 0x1fac0;	// ANATOMICAL HEART
+	charset[i++] = 0x1fac2;	// PEOPLE HUGGING
+	c = 0x1fad0;		// from BLUEBERRIES
+	while (c <= 0x1fad6)	// ..to TEAPOT
+		charset[i++] = c++;
+// 1FB00..1FBFF; Symbols for Legacy Computing
+	c = 0x1fb00;		// from BLOCK SEXTANT-1
+	while (c <= 0x1fb92)	// ..to UPPER HALF INVERSE MEDIUM SHADE AND LOWER HALF BLOCK
+		charset[i++] = c++;
+	c = 0x1fb94;		// from LEFT HALF INVERSE MEDIUM SHADE AND RIGHT HALF BLOCK
+	while (c <= 0x1fbca)	// ..to WHITE UP-POINTING CHEVRON
+		charset[i++] = c++;
+	c = 0x1fbf0;		// from SEGMENTED DIGIT ZERO
+	while (c <= 0x1fbf9)	// ..to SEGMENTED DIGIT NINE
+		charset[i++] = c++;
 // 20000..2A6DF; CJK Unified Ideographs Extension B
 	c = 0x20000;		// from <CJK Ideograph Extension B, First>
-	while (c <= 0x2a6d6)	// ..to <CJK Ideograph Extension B, Last>
+	while (c <= 0x2a6dd)	// ..to <CJK Ideograph Extension B, Last>
 		charset[i++] = c++;
 // 2A700..2B73F; CJK Unified Ideographs Extension C
 	c = 0x2a700;		// from <CJK Ideograph Extension C, First>
@@ -2301,6 +2403,10 @@ void init()
 // 2F800..2FA1F; CJK Compatibility Ideographs Supplement
 	c = 0x2f800;		// from CJK COMPATIBILITY IDEOGRAPH-2F800
 	while (c <= 0x2fa1d)	// ..to CJK COMPATIBILITY IDEOGRAPH-2FA1D
+		charset[i++] = c++;
+// 30000..3134F; CJK Unified Ideographs Extension G
+	c = 0x30000;		// from <CJK Ideograph Extension G, First>
+	while (c <= 0x3134a)	// ..to <CJK Ideograph Extension G, Last>
 		charset[i++] = c++;
 // E0000..E007F; Tags
 	c = 0xe0020;		// from TAG SPACE

--- a/data/jtr/dynamic_disabled.conf
+++ b/data/jtr/dynamic_disabled.conf
@@ -10,7 +10,8 @@ dynamic_57 = Y
 dynamic_58 = Y
 # dyna-61 used by formspring and should not be disabled.
 dynamic_61 = N
-dynamic_62 = Y
+# dyna-62 is ITW
+dynamic_62 = N
 dynamic_63 = Y
 dynamic_64 = Y
 dynamic_65 = Y
@@ -26,7 +27,8 @@ dynamic_76 = Y
 dynamic_77 = Y
 dynamic_78 = Y
 dynamic_81 = Y
-dynamic_82 = Y
+# dyna-82 it ITW  Filezilla
+dynamic_82 = N
 dynamic_83 = Y
 dynamic_84 = Y
 dynamic_85 = Y

--- a/data/jtr/john.conf
+++ b/data/jtr/john.conf
@@ -141,10 +141,10 @@ PotFilePermissions = 0600
 # Default is N
 IgnoreChmodErrors = N
 
-# This figure is in MB. The default is to memory map wordlists not larger
-# than one terabyte.
+# This figure is in MiB. The default is to memory map wordlists not larger
+# than one GiB.
 # Set this to 0 to disable any use of memory-mapping in wordlist mode.
-WordlistMemoryMapMaxSize = 1048576
+WordlistMemoryMapMaxSize = 1024
 
 # For single mode, load the full GECOS field (before splitting) as one
 # additional candidate. Normal behavior is to only load individual words
@@ -172,7 +172,8 @@ SingleSkipLogin = N
 SingleWordsPairMax = 6
 
 # Setting this to false stops Single mode from re-testing guessed plaintexts
-# with all other salts.
+# with all other salts.  This is deprecated: Use command-line per-session
+# option --single-retest-guess=no instead.
 SingleRetestGuessed = Y
 
 # Max recursion depth for SingleRetestGuessed, so we don't blow the stack
@@ -215,7 +216,7 @@ SessionFileProtect = Disabled
 # reused by a new session.
 # (Of course, a restored session will always be allowed to append to an
 # existing log file.)
-# Unless you use the --nolog option, setting LogFileProtect will also
+# Unless you use the --no-log option, setting LogFileProtect will also
 # prevent overwriting existing session files.
 LogFileProtect = Disabled
 
@@ -239,6 +240,7 @@ ShowRemainOnStatus = N
 LogCrackedPasswords = N
 
 # Disable the dupe checking when loading hashes. For testing purposes only!
+# This is deprecated: Use per-session option --loader-dupecheck=no instead.
 NoLoaderDupeCheck = N
 
 # Default encoding for input files (ie. login/GECOS fields) and wordlists
@@ -321,11 +323,11 @@ ReloadAtDone = Y
 # but it may be delayed by the "Save" timer setting near top of this file.
 ReloadAtSave = Y
 
-# If this file exists, john will abort cleanly
-AbortFile = /var/run/john/abort
+# If this file exists, john will abort cleanly (uncomment to enable)
+#AbortFile = /var/run/john/abort
 
-# While this file exists, john will pause
-PauseFile = /var/run/john/pause
+# While this file exists, john will pause (uncomment to enable)
+#PauseFile = /var/run/john/pause
 
 # If set to true, the uid will be appended to user name on cracks
 #   With:     password123      (Administrator:500)
@@ -525,12 +527,12 @@ Frequency = 160
 #Frequency = 160
 # Some bitstreams accept runtime configuration.
 # In sha512crypt/Drupal7, configuration is 2 bytes. That's interpreted
-# as a bitmask. By setting any of the lowest 10 bits to 1 it turns off
-# corresponding unit (there are 10 units in the bitstream).
+# as a bitmask. By setting any of the lowest 12 bits to 1 it turns off
+# the corresponding unit (there are 12 units in the bitstream).
 # This turns off units 0 and 1.
 #Config1 = \x03\x00
-# This turns off all 10 units (resulting in a timeout).
-#Config1_04A36E0FD6_0 = \xff\x03
+# This turns off all 12 units (resulting in a timeout).
+#Config1_04A36E0FD6_0 = \xff\x0f
 
 [ZTEX:sha256crypt]
 # Design tools reported possible frequency is 241 MHz but tested boards
@@ -548,10 +550,10 @@ Frequency = 180
 Frequency = 180
 #TargetRounds = 2048
 
-# These formats are disabled from all-formats --test runs, or auto-selection
-# of format from an input file. Even when disabled, you can use them as long
-# as you spell them out with the --format option. Or you can delete a line,
-# comment it out, or change to 'N'
+# These formats are disabled from listing or self-test/benchmark unless
+# specifically requested.  You can use them as long as you add them out with
+# the --format option.  Or you can delete a line, comment it out, or change
+# to 'N' and the format will be enabled again.
 [Disabled:Formats]
 #formatname = Y
 .include '$JOHN/dynamic_disabled.conf'
@@ -722,7 +724,6 @@ DefaultCharset =
 -c /?d @?d >2 al M [lc] Q d
 (?a )?d /?d a0 'p Xpz0
 )?a (?d /?a a0 'p Xpz0
-
 
 # "Single crack" mode rules
 [List.Rules:Single]
@@ -1015,6 +1016,8 @@ W0Q
 ->F a0 WEQW[z0]W[z1]W[z2]W[z3]W[z4]W[z5]W[z6]W[z7]W[z8]W[z9]W[zA]W[zB]W[zC]W[zD]
 ->G a0 WFQW[z0]W[z1]W[z2]W[z3]W[z4]W[z5]W[z6]W[z7]W[z8]W[z9]W[zA]W[zB]W[zC]W[zD]W[zE]
 
+# This ruleset partially overlaps with some Phrase* rulesets below, but it was
+# historically introduced and made part of the jumbo ruleset first, so it stays
 [List.Rules:Multiword]
 -c /  Dp l
 -c /  Dp c Tp
@@ -1036,6 +1039,49 @@ W0Q
 -c %4[ ] T[0z] \p0[Q:] \p0[M:] va01 vbpa Tb Q M %3[ ] vbpa Tb Q M %2[ ] vbpa Tb Q @?[Zw]
 -c %4[ ] T[0z] \p0[Q:] \p0[M:] va01 vbpa Tb Q M %2[ ] vbpa Tb Q M /[ ] vbpa Tb Q @?[Zw]
 -c %4[ ] T[0z] \p0[Q:] \p0[M:] va01 vbpa Tb Q M %3[ ] vbpa Tb Q M /[ ] vbpa Tb Q @?[Zw]
+
+# A special ruleset intended for stacking before other Phrase* rules below,
+# such that you have the option to run its output through "unique" first
+[List.Rules:PhrasePreprocess]
+/[ ] :
+-c /[ ] l Q
+/[ ] @' Q
+-c /[ ] @' Q M l Q
+
+# The main optimized Phrase ruleset, almost no duplicates with proper input
+[List.Rules:Phrase]
+# This one rule cracks ~1050 HIBP v7 passwords per million with sequences of
+# 2 to 6 words occurring 2+ times across Project Gutenberg Australia books
+# when our sequence list includes them in both their original case and
+# all-lowercase, as well as both with apostrophes intact and removed (these
+# variations are not implemented in this ruleset not to produce duplicates)
+@?w Q
+# Sorted separator characters: 1_24 -.3785690@,&+*!'$/?:=#~^%;`>"[)<]|({}\
+# (the apostrophe is probably overrated since it also occurs inside words)
+# Each character in 1_24 cracks ~82 to ~61 passwords per million
+s[ ][1_24] Q
+# Leaving the space separators intact cracks ~59 passwords per million
+/[ ]
+# Each character in -.3785690@ cracks ~53 to ~12 passwords per million
+s[ ][\-.3785690@] Q
+# Each character in ,&+*!'$/?:=#~ cracks ~10 to ~1 passwords per million
+s[ ][,&+*!'$/?:=#~] Q
+
+# Toggle capitalization of words 1 to 6 individually
+[List.Rules:PhraseCaseOne]
+-c /[ ] T0 Q
+-c /[ ] va01 vapa Ta Q
+-c %2[ ] va01 vapa Ta Q
+-c %3[ ] va01 vapa Ta Q
+-c %4[ ] va01 vapa Ta Q
+-c %5[ ] va01 vapa Ta Q
+
+# Move first word to be after last word
+[List.Rules:PhraseWrap]
+/[ ] ^[ ] Xpz0 \[ 'l
+# Other ways to write this rule
+#/[ ] xpz \[ $[ ] X0pz 'l
+#/[ ] 'p ^[ ] va01 vapa Xaz0
 
 # Used for loopback. This rule will produce candidates "PASSWOR" and "D" for
 # an input of "PASSWORD" (assuming LM, which has halves of length 7).
@@ -1167,6 +1213,9 @@ b1 ]
 .include [List.Rules:Extra]
 .include [List.Rules:OldOffice]
 
+# Unicode substitution rules
+.include <unisubst.conf>
+
 # For Wordlist mode and very fast hashes
 [List.Rules:Jumbo]
 .include [List.Rules:Single-Extra]
@@ -1174,6 +1223,7 @@ b1 ]
 .include [List.Rules:ShiftToggle]
 .include [List.Rules:Multiword]
 .include [List.Rules:best64]
+.include [List.Rules:UnicodeSubstitution]
 
 # KoreLogic rules
 .include <korelogic.conf>
@@ -1189,7 +1239,9 @@ b1 ]
 
 # Incremental modes
 
-# This is for one-off uses (make your own custom.chr)
+# This is for one-off uses (make your own custom.chr).
+# A charset can now also be named directly from command-line, so no config
+# entry needed: --incremental=whatever.chr
 [Incremental:Custom]
 File = $JOHN/custom.chr
 MinLen = 0
@@ -1545,6 +1597,65 @@ void filter()
 			}
 		}
 	}
+	word = 0;
+}
+
+# Skip candidate passwords that contain the same character more than once
+[List.External:Filter_NoRepeats]
+int seen[0x100], now;
+
+void init()
+{
+	now = 1;
+}
+
+void filter()
+{
+	int i, c;
+
+	if (!--now) {
+		i = 0;
+		while (i < 0x100)
+			seen[i++] = 0;
+		now = 1000000000;
+	}
+
+	i = 0;
+	while (c = word[i++]) {
+		if (seen[c] == now) {
+			word = 0; return;
+		}
+		seen[c] = now;
+	}
+}
+
+# Keep only candidate passwords that contain the same character more than once
+[List.External:Filter_Repeats]
+int seen[0x100], now;
+
+void init()
+{
+	now = 1;
+}
+
+void filter()
+{
+	int i, c;
+
+	if (!--now) {
+		i = 0;
+		while (i < 0x100)
+			seen[i++] = 0;
+		now = 1000000000;
+	}
+
+	i = 0;
+	while (c = word[i++]) {
+		if (seen[c] == now)
+			return;
+		seen[c] = now;
+	}
+
 	word = 0;
 }
 
@@ -2167,6 +2278,9 @@ void init()
 # than the maximum length (the maxlength setting).  Nevertheless, you may want
 # to pass the resulting candidate passwords through "unique" if you intend to
 # test them against hashes that are salted and/or of a slow to compute type.
+#
+# Note that we now have a full blown cracking mode --subsets that is way faster
+# than this code and never produce a duplicate.  See doc/SUBSETS
 [List.External:Subsets]
 int minlength;		// Minimum password length to try
 int maxlength;		// Maximum password length to try
@@ -3383,6 +3497,40 @@ void restore()
 	}
 }
 
+# generate all possible wps pins
+[List.External:wpspin]
+int pin;
+void init() {
+	pin = 0;
+}
+void generate() {
+	if (pin > 9999999) {
+		word = 0;
+		return;
+	}
+	int i, p;
+	i = 0;
+	while (i < 8) word[i++] = '0';
+	word[8] = 0;
+	p = pin;
+	i = 6;
+	while (p) {
+		word[i] = '0' + p % 10;
+		p /= 10;
+		--i;
+	}
+	p = pin;
+	i = 0;
+	while (p) {
+		i += 3 * (p % 10);
+		p /= 10;
+		i += p % 10;
+		p /= 10;
+	}
+	word[7] = '0' + ((10 - i % 10) % 10);
+	++pin;
+}
+
 # Append the Luhn algorithm digit to arbitrary all-digit strings.  Optimized
 # for speed, not for size nor simplicity.  The primary optimization trick is to
 # compute the length and four sums in parallel (in two SIMD'ish variables).
@@ -3860,8 +4008,8 @@ void next()
 }
 /* restore() not needed. john properly restores fast enough without it */
 
-# External hybrid CaSE mutation code
-[List.External:Case]
+# Shared base code for External hybrid CaSE and Wordcase mutation code
+[List.External_base:Case]
 
 int rotor[251]; /* max length input is 125 bytes [125*5+1]; */
 int rotors[125];
@@ -3871,17 +4019,12 @@ int rotor_cnt[125];
 int current_word_count;
 int max_mangle; /* controls how many bytes we run through our 'leet' code */
 int original_word; /* if set to 1 then we start with original word. If 0, then start with first mangled word */
-
-void init()
-{
-	max_mangle = 20; /* only mangle 20 characters max (2^20 is 1 million) */
-	original_word = 1; /* for case mangle, unless the data is 100% lower case, we really can not skip the original word */
-}
+int word_mode; /* if set to 1, only first character of each space-separated word is case-toggled, else every character */
 
 /* new word */
 void new()
 {
-	int rotor_off, idx, wlen, ch;
+	int rotor_off, idx, wlen, ch, prevch;
 	idx = rotor_off = wlen = 0;
 	hybrid_total = 1;
 	while (word[wlen++]) ; --wlen;
@@ -3890,24 +4033,32 @@ void new()
 		return;
 	}
 	wlen = 0;
+	prevch = ' '; /* at word start, behave as if previous char was space for wordcase mode */
 	while (word[wlen] && idx < max_mangle) {
 		rotor_cnt[wlen] = rotor_idx[wlen] = 0;
 		rotor_ptr[wlen] = rotor_off;
 		ch = word[wlen];
-		if (ch >= 'A' && ch <= 'Z') {
-			ch += 0x20;
-			word[wlen] = ch;
-			rotor[rotor_off++] = ch;
-			rotor[rotor_off++] = ch-0x20;
-		}
-		if (ch >= 'a' && ch <= 'z') {
-			rotor[rotor_off++] = ch;
-			rotor[rotor_off++] = ch-0x20;
-			rotor_cnt[wlen] = 2;
-			hybrid_total *= 2;
-			rotors[idx++] = wlen;
+		/* traditionally, this block was always executed, with Wordcase
+		   mode added we execute it either always when word_mode isn't
+		   used or at the beginning of a word or when the previous char
+		   was space */
+		if (!word_mode || prevch == ' ') {
+			if (ch >= 'A' && ch <= 'Z') {
+				ch += 0x20;
+				word[wlen] = ch;
+				rotor[rotor_off++] = ch;
+				rotor[rotor_off++] = ch-0x20;
+			}
+			if (ch >= 'a' && ch <= 'z') {
+				rotor[rotor_off++] = ch;
+				rotor[rotor_off++] = ch-0x20;
+				rotor_cnt[wlen] = 2;
+				hybrid_total *= 2;
+				rotors[idx++] = wlen;
+			}
 		}
 		++wlen;
+		prevch = ch;
 	}
 	/* hybrid_total+666 is our indicator that this is the original word */
 	if (original_word)
@@ -3942,8 +4093,36 @@ void next()
 }
 /* restore() not needed. john properly restores fast enough without it */
 
+# External hybrid CaSE mutation code
+[List.External:Case]
+.include [List.External_base:Case]
+
+void init()
+{
+	max_mangle = 20; /* only mangle 20 characters max (2^20 is 1 million) */
+	original_word = 1; /* for case mangle, unless the data is 100% lower case, we really can not skip the original word */
+	word_mode = 0;
+}
+
+
+# external mode toggling case in all word combinations, e.g:
+# foo bar -> foo bar, foo Bar, Foo bar, Foo Bar
+[List.External:Wordcase]
+.include [List.External_base:Case]
+
+void init()
+{
+	max_mangle = 20; /* only mangle 20 characters max (2^20 is 1 million) */
+	original_word = 1; /* for case mangle, unless the data is 100% lower case, we really can not skip the original word */
+	word_mode = 1;
+}
+
 # Alternate hybrid external 'leet' mode (HybridLeet)
 .include <hybrid.conf>
+
+# Note that the (newer) cracking mode --subsets=full-unicode is way faster than
+# the external dumb/repeats modes below, although not as easy to adapt to smaller
+# portions of the Unicode space.  See doc/SUBSETS
 
 # dumb-force UTF-16, in an external file
 .include <dumb16.conf>

--- a/data/jtr/korelogic.conf
+++ b/data/jtr/korelogic.conf
@@ -14,7 +14,7 @@ a6 A0"[Aa][uU][tT][uU][mM][nN]"
 [List.Rules:AppendSeason]
 a6 Az"[Ss$][uU][mM][mM][eE3][rR]"
 a6 Az"[Ww][iI|][nN][tT+][eE3][rR]"
-a6 Az"[Ff][aA][lL][lL]"
+a4 Az"[Ff][aA][lL][lL]"
 a6 Az"[Ss][pP][rR][iI][nN][gG]"
 a6 Az"[Aa][uU][tT][uU][mM][nN]"
 

--- a/data/jtr/repeats16.conf
+++ b/data/jtr/repeats16.conf
@@ -1,16 +1,21 @@
-# This software is Copyright (c) 2012-2018 magnum, and it is hereby
+# This software is Copyright (c) 2012-2020 magnum, and it is hereby
 # released to the general public under the following terms:
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted.
 #
-# Try strings of repeated characters, Unicode (version 11) BMP version
+# Try strings of repeated characters, Unicode (version 13) BMP version
 #
-# Number of candidates = 55,292 x max-length
+# Number of candidates = 55,387 x max-length
 #
 # Note that these modes will handle --max-len differently than normal: They
 # will consider number of characters as opposed to number of bytes. This
 # means you can naturally just use e.g. --max-len=3 for generating all
 # three-character candidates (which may be up to 9 bytes each).
+#
+# Note that the (newer) cracking mode --subsets=full-unicode is way faster than
+# this external mode, although not as easy to adapt to smaller portions of the
+# Unicode space.  See doc/SUBSETS
+
 [List.External:Repeats16]
 int minlength, maxlength, maxc, length, c;
 int charset[0x10000];
@@ -159,7 +164,7 @@ void init()
 	while (c <= 0x8b4)	// ..to ARABIC LETTER KAF WITH DOT BELOW
 		charset[i++] = c++;
 	c = 0x8b6;		// from ARABIC LETTER BEH WITH SMALL MEEM ABOVE
-	while (c <= 0x8bd)	// ..to ARABIC LETTER AFRICAN NOON
+	while (c <= 0x8c7)	// ..to ARABIC LETTER LAM WITH SMALL ARABIC LETTER TAH ABOVE
 		charset[i++] = c++;
 	c = 0x8d3;		// from ARABIC SMALL LOW WAW
 	while (c <= 0x8ff)	// ..to ARABIC MARK SIDEWAYS NOON GHUNNA
@@ -296,7 +301,7 @@ void init()
 	charset[i++] = 0xb48;	// ORIYA VOWEL SIGN AI
 	charset[i++] = 0xb4b;	// ORIYA VOWEL SIGN O
 	charset[i++] = 0xb4d;	// ORIYA SIGN VIRAMA
-	charset[i++] = 0xb56;	// ORIYA AI LENGTH MARK
+	charset[i++] = 0xb55;	// ORIYA SIGN OVERLINE
 	charset[i++] = 0xb57;	// ORIYA AU LENGTH MARK
 	charset[i++] = 0xb5c;	// ORIYA LETTER RRA
 	charset[i++] = 0xb5d;	// ORIYA LETTER RHA
@@ -369,7 +374,7 @@ void init()
 	c = 0xc66;		// from TELUGU DIGIT ZERO
 	while (c <= 0xc6f)	// ..to TELUGU DIGIT NINE
 		charset[i++] = c++;
-	c = 0xc78;		// from TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR
+	c = 0xc77;		// from TELUGU SIGN SIDDHAM
 	while (c <= 0xc7f)	// ..to TELUGU SIGN TUUMU
 		charset[i++] = c++;
 // 0C80..0CFF; Kannada
@@ -407,9 +412,6 @@ void init()
 	charset[i++] = 0xcf2;	// KANNADA SIGN UPADHMANIYA
 // 0D00..0D7F; Malayalam
 	c = 0xd00;		// from MALAYALAM SIGN COMBINING ANUSVARA ABOVE
-	while (c <= 0xd03)	// ..to MALAYALAM SIGN VISARGA
-		charset[i++] = c++;
-	c = 0xd05;		// from MALAYALAM LETTER A
 	while (c <= 0xd0c)	// ..to MALAYALAM LETTER VOCALIC L
 		charset[i++] = c++;
 	charset[i++] = 0xd0e;	// MALAYALAM LETTER E
@@ -429,7 +431,7 @@ void init()
 	while (c <= 0xd7f)	// ..to MALAYALAM LETTER CHILLU K
 		charset[i++] = c++;
 // 0D80..0DFF; Sinhala
-	charset[i++] = 0xd82;	// SINHALA SIGN ANUSVARAYA
+	charset[i++] = 0xd81;	// SINHALA SIGN CANDRABINDU
 	charset[i++] = 0xd83;	// SINHALA SIGN VISARGAYA
 	c = 0xd85;		// from SINHALA LETTER AYANNA
 	while (c <= 0xd96)	// ..to SINHALA LETTER AUYANNA
@@ -464,23 +466,15 @@ void init()
 // 0E80..0EFF; Lao
 	charset[i++] = 0xe81;	// LAO LETTER KO
 	charset[i++] = 0xe82;	// LAO LETTER KHO SUNG
-	charset[i++] = 0xe87;	// LAO LETTER NGO
-	charset[i++] = 0xe88;	// LAO LETTER CO
-	c = 0xe94;		// from LAO LETTER DO
-	while (c <= 0xe97)	// ..to LAO LETTER THO TAM
+	c = 0xe86;		// from LAO LETTER PALI GHA
+	while (c <= 0xe8a)	// ..to LAO LETTER SO TAM
 		charset[i++] = c++;
-	c = 0xe99;		// from LAO LETTER NO
-	while (c <= 0xe9f)	// ..to LAO LETTER FO SUNG
+	c = 0xe8c;		// from LAO LETTER PALI JHA
+	while (c <= 0xea3)	// ..to LAO LETTER LO LING
 		charset[i++] = c++;
-	charset[i++] = 0xea1;	// LAO LETTER MO
-	charset[i++] = 0xea3;	// LAO LETTER LO LING
-	charset[i++] = 0xeaa;	// LAO LETTER SO SUNG
-	charset[i++] = 0xeab;	// LAO LETTER HO SUNG
-	c = 0xead;		// from LAO LETTER O
-	while (c <= 0xeb9)	// ..to LAO VOWEL SIGN UU
+	c = 0xea7;		// from LAO LETTER WO
+	while (c <= 0xebd)	// ..to LAO SEMIVOWEL SIGN NYO
 		charset[i++] = c++;
-	charset[i++] = 0xebb;	// LAO VOWEL SIGN MAI KON
-	charset[i++] = 0xebd;	// LAO SEMIVOWEL SIGN NYO
 	c = 0xec0;		// from LAO VOWEL SIGN E
 	while (c <= 0xec4)	// ..to LAO VOWEL SIGN AI
 		charset[i++] = c++;
@@ -706,7 +700,7 @@ void init()
 		charset[i++] = c++;
 // 1AB0..1AFF; Combining Diacritical Marks Extended
 	c = 0x1ab0;		// from COMBINING DOUBLED CIRCUMFLEX ACCENT
-	while (c <= 0x1abe)	// ..to COMBINING PARENTHESES OVERLAY
+	while (c <= 0x1ac0)	// ..to COMBINING LATIN SMALL LETTER TURNED W BELOW
 		charset[i++] = c++;
 // 1B00..1B7F; Balinese
 	c = 0x1b00;		// from BALINESE SIGN ULU RICEM
@@ -755,7 +749,7 @@ void init()
 		charset[i++] = c++;
 // 1CD0..1CFF; Vedic Extensions
 	c = 0x1cd0;		// from VEDIC TONE KARSHANA
-	while (c <= 0x1cf9)	// ..to VEDIC TONE DOUBLE RING ABOVE
+	while (c <= 0x1cfa)	// ..to VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
 		charset[i++] = c++;
 // 1D00..1D7F; Phonetic Extensions
 	c = 0x1d00;		// from LATIN LETTER SMALL CAPITAL A
@@ -922,11 +916,8 @@ void init()
 	c = 0x2b76;		// from NORTH WEST TRIANGLE-HEADED ARROW TO BAR
 	while (c <= 0x2b95)	// ..to RIGHTWARDS BLACK ARROW
 		charset[i++] = c++;
-	c = 0x2b98;		// from THREE-D TOP-LIGHTED LEFTWARDS EQUILATERAL ARROWHEAD
-	while (c <= 0x2bc8)	// ..to BLACK MEDIUM RIGHT-POINTING TRIANGLE CENTRED
-		charset[i++] = c++;
-	c = 0x2bca;		// from TOP HALF BLACK CIRCLE
-	while (c <= 0x2bfe)	// ..to REVERSED RIGHT ANGLE
+	c = 0x2b97;		// from SYMBOL FOR TYPE A ELECTRONICS
+	while (c <= 0x2bff)	// ..to HELLSCHREIBER PAUSE SYMBOL
 		charset[i++] = c++;
 // 2C00..2C5F; Glagolitic
 	c = 0x2c00;		// from GLAGOLITIC CAPITAL LETTER AZU
@@ -994,7 +985,7 @@ void init()
 		charset[i++] = c++;
 // 2E00..2E7F; Supplemental Punctuation
 	c = 0x2e00;		// from RIGHT ANGLE SUBSTITUTION MARKER
-	while (c <= 0x2e4e)	// ..to PUNCTUS ELEVATUS MARK
+	while (c <= 0x2e52)	// ..to TIRONIAN SIGN CAPITAL ET
 		charset[i++] = c++;
 // 2E80..2EFF; CJK Radicals Supplement
 	c = 0x2e80;		// from CJK RADICAL REPEAT
@@ -1040,7 +1031,7 @@ void init()
 		charset[i++] = c++;
 // 31A0..31BF; Bopomofo Extended
 	c = 0x31a0;		// from BOPOMOFO LETTER BU
-	while (c <= 0x31ba)	// ..to BOPOMOFO LETTER ZY
+	while (c <= 0x31bf)	// ..to BOPOMOFO LETTER AH
 		charset[i++] = c++;
 // 31C0..31EF; CJK Strokes
 	c = 0x31c0;		// from CJK STROKE T
@@ -1055,7 +1046,7 @@ void init()
 	while (c <= 0x321e)	// ..to PARENTHESIZED KOREAN CHARACTER O HU
 		charset[i++] = c++;
 	c = 0x3220;		// from PARENTHESIZED IDEOGRAPH ONE
-	while (c <= 0x32fe)	// ..to CIRCLED KATAKANA WO
+	while (c <= 0x32ff)	// ..to SQUARE ERA NAME REIWA
 		charset[i++] = c++;
 // 3300..33FF; CJK Compatibility
 	c = 0x3300;		// from SQUARE APAATO
@@ -1063,7 +1054,7 @@ void init()
 		charset[i++] = c++;
 // 3400..4DBF; CJK Unified Ideographs Extension A
 	c = 0x3400;		// from <CJK Ideograph Extension A, First>
-	while (c <= 0x4db5)	// ..to <CJK Ideograph Extension A, Last>
+	while (c <= 0x4dbf)	// ..to <CJK Ideograph Extension A, Last>
 		charset[i++] = c++;
 // 4DC0..4DFF; Yijing Hexagram Symbols
 	c = 0x4dc0;		// from HEXAGRAM FOR THE CREATIVE HEAVEN
@@ -1071,7 +1062,7 @@ void init()
 		charset[i++] = c++;
 // 4E00..9FFF; CJK Unified Ideographs
 	c = 0x4e00;		// from <CJK Ideograph, First>
-	while (c <= 0x9fef)	// ..to <CJK Ideograph, Last>
+	while (c <= 0x9ffc)	// ..to <CJK Ideograph, Last>
 		charset[i++] = c++;
 // A000..A48F; Yi Syllables
 	c = 0xa000;		// from YI SYLLABLE IT
@@ -1103,14 +1094,17 @@ void init()
 		charset[i++] = c++;
 // A720..A7FF; Latin Extended-D
 	c = 0xa720;		// from MODIFIER LETTER STRESS AND HIGH TONE
-	while (c <= 0xa7b9)	// ..to LATIN SMALL LETTER U WITH STROKE
+	while (c <= 0xa7bf)	// ..to LATIN SMALL LETTER GLOTTAL U
 		charset[i++] = c++;
-	c = 0xa7f7;		// from LATIN EPIGRAPHIC LETTER SIDEWAYS I
+	c = 0xa7c2;		// from LATIN CAPITAL LETTER ANGLICANA W
+	while (c <= 0xa7ca)	// ..to LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+		charset[i++] = c++;
+	c = 0xa7f5;		// from LATIN CAPITAL LETTER REVERSED HALF H
 	while (c <= 0xa7ff)	// ..to LATIN EPIGRAPHIC LETTER ARCHAIC M
 		charset[i++] = c++;
 // A800..A82F; Syloti Nagri
 	c = 0xa800;		// from SYLOTI NAGRI LETTER A
-	while (c <= 0xa82b)	// ..to SYLOTI NAGRI POETRY MARK-4
+	while (c <= 0xa82c)	// ..to SYLOTI NAGRI SIGN ALTERNATE HASANTA
 		charset[i++] = c++;
 // A830..A83F; Common Indic Number Forms
 	c = 0xa830;		// from NORTH INDIC FRACTION ONE QUARTER
@@ -1203,7 +1197,7 @@ void init()
 		charset[i++] = c++;
 // AB30..AB6F; Latin Extended-E
 	c = 0xab30;		// from LATIN SMALL LETTER BARRED ALPHA
-	while (c <= 0xab65)	// ..to GREEK LETTER SMALL CAPITAL OMEGA
+	while (c <= 0xab6b)	// ..to MODIFIER LETTER RIGHT TACK
 		charset[i++] = c++;
 // AB70..ABBF; Cherokee Supplement
 	c = 0xab70;		// from CHEROKEE SMALL LETTER A

--- a/data/jtr/repeats32.conf
+++ b/data/jtr/repeats32.conf
@@ -1,11 +1,11 @@
-# This software is Copyright (c) 2012-2018 magnum, and it is hereby
+# This software is Copyright (c) 2012-2020 magnum, and it is hereby
 # released to the general public under the following terms:
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted.
 #
-# Try strings of repeated characters, Full Unicode (version 11) version
+# Try strings of repeated characters, Full Unicode (version 13) version
 #
-# Number of candidates = 137,046 x length
+# Number of candidates = 143,532 x length
 #
 # Note that these modes will handle --max-len differently than normal: They
 # will consider number of characters as opposed to number of bytes. This
@@ -16,9 +16,14 @@
 # format will be up to four bytes (two 16-bit words) due to use of surrogates
 # for characters above U+FFFF. This means a format which normally handles up
 # to 27 characters may be limited to only 13 characters, worst case.
+#
+# Note that the (newer) cracking mode --subsets=full-unicode is way faster than
+# this external mode, although not as easy to adapt to smaller portions of the
+# Unicode space.  See doc/SUBSETS
+
 [List.External:Repeats32]
 int minlength, maxlength, maxc, length, c;
-int charset[0x22000];
+int charset[0x24000];
 
 void init()
 {
@@ -164,7 +169,7 @@ void init()
 	while (c <= 0x8b4)	// ..to ARABIC LETTER KAF WITH DOT BELOW
 		charset[i++] = c++;
 	c = 0x8b6;		// from ARABIC LETTER BEH WITH SMALL MEEM ABOVE
-	while (c <= 0x8bd)	// ..to ARABIC LETTER AFRICAN NOON
+	while (c <= 0x8c7)	// ..to ARABIC LETTER LAM WITH SMALL ARABIC LETTER TAH ABOVE
 		charset[i++] = c++;
 	c = 0x8d3;		// from ARABIC SMALL LOW WAW
 	while (c <= 0x8ff)	// ..to ARABIC MARK SIDEWAYS NOON GHUNNA
@@ -301,7 +306,7 @@ void init()
 	charset[i++] = 0xb48;	// ORIYA VOWEL SIGN AI
 	charset[i++] = 0xb4b;	// ORIYA VOWEL SIGN O
 	charset[i++] = 0xb4d;	// ORIYA SIGN VIRAMA
-	charset[i++] = 0xb56;	// ORIYA AI LENGTH MARK
+	charset[i++] = 0xb55;	// ORIYA SIGN OVERLINE
 	charset[i++] = 0xb57;	// ORIYA AU LENGTH MARK
 	charset[i++] = 0xb5c;	// ORIYA LETTER RRA
 	charset[i++] = 0xb5d;	// ORIYA LETTER RHA
@@ -374,7 +379,7 @@ void init()
 	c = 0xc66;		// from TELUGU DIGIT ZERO
 	while (c <= 0xc6f)	// ..to TELUGU DIGIT NINE
 		charset[i++] = c++;
-	c = 0xc78;		// from TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR
+	c = 0xc77;		// from TELUGU SIGN SIDDHAM
 	while (c <= 0xc7f)	// ..to TELUGU SIGN TUUMU
 		charset[i++] = c++;
 // 0C80..0CFF; Kannada
@@ -412,9 +417,6 @@ void init()
 	charset[i++] = 0xcf2;	// KANNADA SIGN UPADHMANIYA
 // 0D00..0D7F; Malayalam
 	c = 0xd00;		// from MALAYALAM SIGN COMBINING ANUSVARA ABOVE
-	while (c <= 0xd03)	// ..to MALAYALAM SIGN VISARGA
-		charset[i++] = c++;
-	c = 0xd05;		// from MALAYALAM LETTER A
 	while (c <= 0xd0c)	// ..to MALAYALAM LETTER VOCALIC L
 		charset[i++] = c++;
 	charset[i++] = 0xd0e;	// MALAYALAM LETTER E
@@ -434,7 +436,7 @@ void init()
 	while (c <= 0xd7f)	// ..to MALAYALAM LETTER CHILLU K
 		charset[i++] = c++;
 // 0D80..0DFF; Sinhala
-	charset[i++] = 0xd82;	// SINHALA SIGN ANUSVARAYA
+	charset[i++] = 0xd81;	// SINHALA SIGN CANDRABINDU
 	charset[i++] = 0xd83;	// SINHALA SIGN VISARGAYA
 	c = 0xd85;		// from SINHALA LETTER AYANNA
 	while (c <= 0xd96)	// ..to SINHALA LETTER AUYANNA
@@ -469,23 +471,15 @@ void init()
 // 0E80..0EFF; Lao
 	charset[i++] = 0xe81;	// LAO LETTER KO
 	charset[i++] = 0xe82;	// LAO LETTER KHO SUNG
-	charset[i++] = 0xe87;	// LAO LETTER NGO
-	charset[i++] = 0xe88;	// LAO LETTER CO
-	c = 0xe94;		// from LAO LETTER DO
-	while (c <= 0xe97)	// ..to LAO LETTER THO TAM
+	c = 0xe86;		// from LAO LETTER PALI GHA
+	while (c <= 0xe8a)	// ..to LAO LETTER SO TAM
 		charset[i++] = c++;
-	c = 0xe99;		// from LAO LETTER NO
-	while (c <= 0xe9f)	// ..to LAO LETTER FO SUNG
+	c = 0xe8c;		// from LAO LETTER PALI JHA
+	while (c <= 0xea3)	// ..to LAO LETTER LO LING
 		charset[i++] = c++;
-	charset[i++] = 0xea1;	// LAO LETTER MO
-	charset[i++] = 0xea3;	// LAO LETTER LO LING
-	charset[i++] = 0xeaa;	// LAO LETTER SO SUNG
-	charset[i++] = 0xeab;	// LAO LETTER HO SUNG
-	c = 0xead;		// from LAO LETTER O
-	while (c <= 0xeb9)	// ..to LAO VOWEL SIGN UU
+	c = 0xea7;		// from LAO LETTER WO
+	while (c <= 0xebd)	// ..to LAO SEMIVOWEL SIGN NYO
 		charset[i++] = c++;
-	charset[i++] = 0xebb;	// LAO VOWEL SIGN MAI KON
-	charset[i++] = 0xebd;	// LAO SEMIVOWEL SIGN NYO
 	c = 0xec0;		// from LAO VOWEL SIGN E
 	while (c <= 0xec4)	// ..to LAO VOWEL SIGN AI
 		charset[i++] = c++;
@@ -711,7 +705,7 @@ void init()
 		charset[i++] = c++;
 // 1AB0..1AFF; Combining Diacritical Marks Extended
 	c = 0x1ab0;		// from COMBINING DOUBLED CIRCUMFLEX ACCENT
-	while (c <= 0x1abe)	// ..to COMBINING PARENTHESES OVERLAY
+	while (c <= 0x1ac0)	// ..to COMBINING LATIN SMALL LETTER TURNED W BELOW
 		charset[i++] = c++;
 // 1B00..1B7F; Balinese
 	c = 0x1b00;		// from BALINESE SIGN ULU RICEM
@@ -760,7 +754,7 @@ void init()
 		charset[i++] = c++;
 // 1CD0..1CFF; Vedic Extensions
 	c = 0x1cd0;		// from VEDIC TONE KARSHANA
-	while (c <= 0x1cf9)	// ..to VEDIC TONE DOUBLE RING ABOVE
+	while (c <= 0x1cfa)	// ..to VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
 		charset[i++] = c++;
 // 1D00..1D7F; Phonetic Extensions
 	c = 0x1d00;		// from LATIN LETTER SMALL CAPITAL A
@@ -927,11 +921,8 @@ void init()
 	c = 0x2b76;		// from NORTH WEST TRIANGLE-HEADED ARROW TO BAR
 	while (c <= 0x2b95)	// ..to RIGHTWARDS BLACK ARROW
 		charset[i++] = c++;
-	c = 0x2b98;		// from THREE-D TOP-LIGHTED LEFTWARDS EQUILATERAL ARROWHEAD
-	while (c <= 0x2bc8)	// ..to BLACK MEDIUM RIGHT-POINTING TRIANGLE CENTRED
-		charset[i++] = c++;
-	c = 0x2bca;		// from TOP HALF BLACK CIRCLE
-	while (c <= 0x2bfe)	// ..to REVERSED RIGHT ANGLE
+	c = 0x2b97;		// from SYMBOL FOR TYPE A ELECTRONICS
+	while (c <= 0x2bff)	// ..to HELLSCHREIBER PAUSE SYMBOL
 		charset[i++] = c++;
 // 2C00..2C5F; Glagolitic
 	c = 0x2c00;		// from GLAGOLITIC CAPITAL LETTER AZU
@@ -999,7 +990,7 @@ void init()
 		charset[i++] = c++;
 // 2E00..2E7F; Supplemental Punctuation
 	c = 0x2e00;		// from RIGHT ANGLE SUBSTITUTION MARKER
-	while (c <= 0x2e4e)	// ..to PUNCTUS ELEVATUS MARK
+	while (c <= 0x2e52)	// ..to TIRONIAN SIGN CAPITAL ET
 		charset[i++] = c++;
 // 2E80..2EFF; CJK Radicals Supplement
 	c = 0x2e80;		// from CJK RADICAL REPEAT
@@ -1045,7 +1036,7 @@ void init()
 		charset[i++] = c++;
 // 31A0..31BF; Bopomofo Extended
 	c = 0x31a0;		// from BOPOMOFO LETTER BU
-	while (c <= 0x31ba)	// ..to BOPOMOFO LETTER ZY
+	while (c <= 0x31bf)	// ..to BOPOMOFO LETTER AH
 		charset[i++] = c++;
 // 31C0..31EF; CJK Strokes
 	c = 0x31c0;		// from CJK STROKE T
@@ -1060,7 +1051,7 @@ void init()
 	while (c <= 0x321e)	// ..to PARENTHESIZED KOREAN CHARACTER O HU
 		charset[i++] = c++;
 	c = 0x3220;		// from PARENTHESIZED IDEOGRAPH ONE
-	while (c <= 0x32fe)	// ..to CIRCLED KATAKANA WO
+	while (c <= 0x32ff)	// ..to SQUARE ERA NAME REIWA
 		charset[i++] = c++;
 // 3300..33FF; CJK Compatibility
 	c = 0x3300;		// from SQUARE APAATO
@@ -1068,7 +1059,7 @@ void init()
 		charset[i++] = c++;
 // 3400..4DBF; CJK Unified Ideographs Extension A
 	c = 0x3400;		// from <CJK Ideograph Extension A, First>
-	while (c <= 0x4db5)	// ..to <CJK Ideograph Extension A, Last>
+	while (c <= 0x4dbf)	// ..to <CJK Ideograph Extension A, Last>
 		charset[i++] = c++;
 // 4DC0..4DFF; Yijing Hexagram Symbols
 	c = 0x4dc0;		// from HEXAGRAM FOR THE CREATIVE HEAVEN
@@ -1076,7 +1067,7 @@ void init()
 		charset[i++] = c++;
 // 4E00..9FFF; CJK Unified Ideographs
 	c = 0x4e00;		// from <CJK Ideograph, First>
-	while (c <= 0x9fef)	// ..to <CJK Ideograph, Last>
+	while (c <= 0x9ffc)	// ..to <CJK Ideograph, Last>
 		charset[i++] = c++;
 // A000..A48F; Yi Syllables
 	c = 0xa000;		// from YI SYLLABLE IT
@@ -1108,14 +1099,17 @@ void init()
 		charset[i++] = c++;
 // A720..A7FF; Latin Extended-D
 	c = 0xa720;		// from MODIFIER LETTER STRESS AND HIGH TONE
-	while (c <= 0xa7b9)	// ..to LATIN SMALL LETTER U WITH STROKE
+	while (c <= 0xa7bf)	// ..to LATIN SMALL LETTER GLOTTAL U
 		charset[i++] = c++;
-	c = 0xa7f7;		// from LATIN EPIGRAPHIC LETTER SIDEWAYS I
+	c = 0xa7c2;		// from LATIN CAPITAL LETTER ANGLICANA W
+	while (c <= 0xa7ca)	// ..to LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+		charset[i++] = c++;
+	c = 0xa7f5;		// from LATIN CAPITAL LETTER REVERSED HALF H
 	while (c <= 0xa7ff)	// ..to LATIN EPIGRAPHIC LETTER ARCHAIC M
 		charset[i++] = c++;
 // A800..A82F; Syloti Nagri
 	c = 0xa800;		// from SYLOTI NAGRI LETTER A
-	while (c <= 0xa82b)	// ..to SYLOTI NAGRI POETRY MARK-4
+	while (c <= 0xa82c)	// ..to SYLOTI NAGRI SIGN ALTERNATE HASANTA
 		charset[i++] = c++;
 // A830..A83F; Common Indic Number Forms
 	c = 0xa830;		// from NORTH INDIC FRACTION ONE QUARTER
@@ -1208,7 +1202,7 @@ void init()
 		charset[i++] = c++;
 // AB30..AB6F; Latin Extended-E
 	c = 0xab30;		// from LATIN SMALL LETTER BARRED ALPHA
-	while (c <= 0xab65)	// ..to GREEK LETTER SMALL CAPITAL OMEGA
+	while (c <= 0xab6b)	// ..to MODIFIER LETTER RIGHT TACK
 		charset[i++] = c++;
 // AB70..ABBF; Cherokee Supplement
 	c = 0xab70;		// from CHEROKEE SMALL LETTER A
@@ -1374,7 +1368,7 @@ void init()
 		charset[i++] = c++;
 // 10190..101CF; Ancient Symbols
 	c = 0x10190;		// from ROMAN SEXTANS SIGN
-	while (c <= 0x1019b)	// ..to ROMAN CENTURIAL SIGN
+	while (c <= 0x1019c)	// ..to ASCIA SYMBOL
 		charset[i++] = c++;
 	charset[i++] = 0x101a0;	// GREEK SYMBOL TAU RHO
 // 101D0..101FF; Phaistos Disc
@@ -1616,6 +1610,14 @@ void init()
 	c = 0x10e60;		// from RUMI DIGIT ONE
 	while (c <= 0x10e7e)	// ..to RUMI FRACTION TWO THIRDS
 		charset[i++] = c++;
+// 10E80..10EBF; Yezidi
+	c = 0x10e80;		// from YEZIDI LETTER ELIF
+	while (c <= 0x10ea9)	// ..to YEZIDI LETTER ET
+		charset[i++] = c++;
+	charset[i++] = 0x10eab;	// YEZIDI COMBINING HAMZA MARK
+	charset[i++] = 0x10ead;	// YEZIDI HYPHENATION MARK
+	charset[i++] = 0x10eb0;	// YEZIDI LETTER LAM WITH DOT ABOVE
+	charset[i++] = 0x10eb1;	// YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
 // 10F00..10F2F; Old Sogdian
 	c = 0x10f00;		// from OLD SOGDIAN LETTER ALEPH
 	while (c <= 0x10f27)	// ..to OLD SOGDIAN LIGATURE AYIN-DALETH
@@ -1623,6 +1625,14 @@ void init()
 // 10F30..10F6F; Sogdian
 	c = 0x10f30;		// from SOGDIAN LETTER ALEPH
 	while (c <= 0x10f59)	// ..to SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
+		charset[i++] = c++;
+// 10FB0..10FDF; Chorasmian
+	c = 0x10fb0;		// from CHORASMIAN LETTER ALEPH
+	while (c <= 0x10fcb)	// ..to CHORASMIAN NUMBER ONE HUNDRED
+		charset[i++] = c++;
+// 10FE0..10FFF; Elymaic
+	c = 0x10fe0;		// from ELYMAIC LETTER ALEPH
+	while (c <= 0x10ff6)	// ..to ELYMAIC LIGATURE ZAYIN-YODH
 		charset[i++] = c++;
 // 11000..1107F; Brahmi
 	c = 0x11000;		// from BRAHMI SIGN CANDRABINDU
@@ -1649,7 +1659,7 @@ void init()
 	while (c <= 0x11134)	// ..to CHAKMA MAAYYAA
 		charset[i++] = c++;
 	c = 0x11136;		// from CHAKMA DIGIT ZERO
-	while (c <= 0x11146)	// ..to CHAKMA VOWEL SIGN EI
+	while (c <= 0x11147)	// ..to CHAKMA LETTER VAA
 		charset[i++] = c++;
 // 11150..1117F; Mahajani
 	c = 0x11150;		// from MAHAJANI LETTER A
@@ -1657,9 +1667,6 @@ void init()
 		charset[i++] = c++;
 // 11180..111DF; Sharada
 	c = 0x11180;		// from SHARADA SIGN CANDRABINDU
-	while (c <= 0x111cd)	// ..to SHARADA SUTRA MARK
-		charset[i++] = c++;
-	c = 0x111d0;		// from SHARADA DIGIT ZERO
 	while (c <= 0x111df)	// ..to SHARADA SECTION MARK-2
 		charset[i++] = c++;
 // 111E0..111FF; Sinhala Archaic Numbers
@@ -1731,10 +1738,11 @@ void init()
 		charset[i++] = c++;
 // 11400..1147F; Newa
 	c = 0x11400;		// from NEWA LETTER A
-	while (c <= 0x11459)	// ..to NEWA DIGIT NINE
+	while (c <= 0x1145b)	// ..to NEWA PLACEHOLDER MARK
 		charset[i++] = c++;
-	charset[i++] = 0x1145d;	// NEWA INSERTION SIGN
-	charset[i++] = 0x1145e;	// NEWA SANDHI MARK
+	c = 0x1145d;		// from NEWA INSERTION SIGN
+	while (c <= 0x11461)	// ..to NEWA SIGN UPADHMANIYA
+		charset[i++] = c++;
 // 11480..114DF; Tirhuta
 	c = 0x11480;		// from TIRHUTA ANJI
 	while (c <= 0x114c7)	// ..to TIRHUTA OM
@@ -1762,7 +1770,7 @@ void init()
 		charset[i++] = c++;
 // 11680..116CF; Takri
 	c = 0x11680;		// from TAKRI LETTER A
-	while (c <= 0x116b7)	// ..to TAKRI SIGN NUKTA
+	while (c <= 0x116b8)	// ..to TAKRI LETTER ARCHAIC KHA
 		charset[i++] = c++;
 	c = 0x116c0;		// from TAKRI DIGIT ZERO
 	while (c <= 0x116c9)	// ..to TAKRI DIGIT NINE
@@ -1786,15 +1794,42 @@ void init()
 	while (c <= 0x118f2)	// ..to WARANG CITI NUMBER NINETY
 		charset[i++] = c++;
 	charset[i++] = 0x118ff;	// WARANG CITI OM
+// 11900..1195F; Dives Akuru
+	c = 0x11900;		// from DIVES AKURU LETTER A
+	while (c <= 0x11906)	// ..to DIVES AKURU LETTER E
+		charset[i++] = c++;
+	c = 0x1190c;		// from DIVES AKURU LETTER KA
+	while (c <= 0x11913)	// ..to DIVES AKURU LETTER JA
+		charset[i++] = c++;
+	charset[i++] = 0x11915;	// DIVES AKURU LETTER NYA
+	charset[i++] = 0x11916;	// DIVES AKURU LETTER TTA
+	c = 0x11918;		// from DIVES AKURU LETTER DDA
+	while (c <= 0x11935)	// ..to DIVES AKURU VOWEL SIGN E
+		charset[i++] = c++;
+	charset[i++] = 0x11937;	// DIVES AKURU VOWEL SIGN AI
+	charset[i++] = 0x11938;	// DIVES AKURU VOWEL SIGN O
+	c = 0x1193b;		// from DIVES AKURU SIGN ANUSVARA
+	while (c <= 0x11946)	// ..to DIVES AKURU END OF TEXT MARK
+		charset[i++] = c++;
+	c = 0x11950;		// from DIVES AKURU DIGIT ZERO
+	while (c <= 0x11959)	// ..to DIVES AKURU DIGIT NINE
+		charset[i++] = c++;
+// 119A0..119FF; Nandinagari
+	c = 0x119a0;		// from NANDINAGARI LETTER A
+	while (c <= 0x119a7)	// ..to NANDINAGARI LETTER VOCALIC RR
+		charset[i++] = c++;
+	c = 0x119aa;		// from NANDINAGARI LETTER E
+	while (c <= 0x119d7)	// ..to NANDINAGARI VOWEL SIGN VOCALIC RR
+		charset[i++] = c++;
+	c = 0x119da;		// from NANDINAGARI VOWEL SIGN E
+	while (c <= 0x119e4)	// ..to NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+		charset[i++] = c++;
 // 11A00..11A4F; Zanabazar Square
 	c = 0x11a00;		// from ZANABAZAR SQUARE LETTER A
 	while (c <= 0x11a47)	// ..to ZANABAZAR SQUARE SUBJOINER
 		charset[i++] = c++;
 // 11A50..11AAF; Soyombo
 	c = 0x11a50;		// from SOYOMBO LETTER A
-	while (c <= 0x11a83)	// ..to SOYOMBO LETTER KSSA
-		charset[i++] = c++;
-	c = 0x11a86;		// from SOYOMBO CLUSTER-INITIAL LETTER RA
 	while (c <= 0x11aa2)	// ..to SOYOMBO TERMINAL MARK-2
 		charset[i++] = c++;
 // 11AC0..11AFF; Pau Cin Hau
@@ -1862,6 +1897,13 @@ void init()
 	c = 0x11ee0;		// from MAKASAR LETTER KA
 	while (c <= 0x11ef8)	// ..to MAKASAR END OF SECTION
 		charset[i++] = c++;
+// 11FB0..11FBF; Lisu Supplement
+	charset[i++] = 0x11fb0;	// LISU LETTER YHA
+// 11FC0..11FFF; Tamil Supplement
+	c = 0x11fc0;		// from TAMIL FRACTION ONE THREE-HUNDRED-AND-TWENTIETH
+	while (c <= 0x11ff1)	// ..to TAMIL SIGN VAKAIYARAA
+		charset[i++] = c++;
+	charset[i++] = 0x11fff;	// TAMIL PUNCTUATION END OF TEXT
 // 12000..123FF; Cuneiform
 	c = 0x12000;		// from CUNEIFORM SIGN A
 	while (c <= 0x12399)	// ..to CUNEIFORM SIGN U U
@@ -1880,6 +1922,10 @@ void init()
 // 13000..1342F; Egyptian Hieroglyphs
 	c = 0x13000;		// from EGYPTIAN HIEROGLYPH A001
 	while (c <= 0x1342e)	// ..to EGYPTIAN HIEROGLYPH AA032
+		charset[i++] = c++;
+// 13430..1343F; Egyptian Hieroglyph Format Controls
+	c = 0x13430;		// from EGYPTIAN HIEROGLYPH VERTICAL JOINER
+	while (c <= 0x13438)	// ..to EGYPTIAN HIEROGLYPH END SEGMENT
 		charset[i++] = c++;
 // 14400..1467F; Anatolian Hieroglyphs
 	c = 0x14400;		// from ANATOLIAN HIEROGLYPH A001
@@ -1927,24 +1973,35 @@ void init()
 		charset[i++] = c++;
 // 16F00..16F9F; Miao
 	c = 0x16f00;		// from MIAO LETTER PA
-	while (c <= 0x16f44)	// ..to MIAO LETTER HHA
+	while (c <= 0x16f4a)	// ..to MIAO LETTER RTE
 		charset[i++] = c++;
-	c = 0x16f50;		// from MIAO LETTER NASALIZATION
-	while (c <= 0x16f7e)	// ..to MIAO VOWEL SIGN NG
+	c = 0x16f4f;		// from MIAO SIGN CONSONANT MODIFIER BAR
+	while (c <= 0x16f87)	// ..to MIAO VOWEL SIGN UI
 		charset[i++] = c++;
 	c = 0x16f8f;		// from MIAO TONE RIGHT
 	while (c <= 0x16f9f)	// ..to MIAO LETTER REFORMED TONE-8
 		charset[i++] = c++;
 // 16FE0..16FFF; Ideographic Symbols and Punctuation
-	charset[i++] = 0x16fe0;	// TANGUT ITERATION MARK
-	charset[i++] = 0x16fe1;	// NUSHU ITERATION MARK
+	c = 0x16fe0;		// from TANGUT ITERATION MARK
+	while (c <= 0x16fe4)	// ..to KHITAN SMALL SCRIPT FILLER
+		charset[i++] = c++;
+	charset[i++] = 0x16ff0;	// VIETNAMESE ALTERNATE READING MARK CA
+	charset[i++] = 0x16ff1;	// VIETNAMESE ALTERNATE READING MARK NHAY
 // 17000..187FF; Tangut
 	c = 0x17000;		// from <Tangut Ideograph, First>
-	while (c <= 0x187f1)	// ..to <Tangut Ideograph, Last>
+	while (c <= 0x187f7)	// ..to <Tangut Ideograph, Last>
 		charset[i++] = c++;
 // 18800..18AFF; Tangut Components
 	c = 0x18800;		// from TANGUT COMPONENT-001
-	while (c <= 0x18af2)	// ..to TANGUT COMPONENT-755
+	while (c <= 0x18aff)	// ..to TANGUT COMPONENT-768
+		charset[i++] = c++;
+// 18B00..18CFF; Khitan Small Script
+	c = 0x18b00;		// from KHITAN SMALL SCRIPT CHARACTER-18B00
+	while (c <= 0x18cd5)	// ..to KHITAN SMALL SCRIPT CHARACTER-18CD5
+		charset[i++] = c++;
+// 18D00..18D8F; Tangut Supplement
+	c = 0x18d00;		// from <Tangut Ideograph Supplement, First>
+	while (c <= 0x18d08)	// ..to <Tangut Ideograph Supplement, Last>
 		charset[i++] = c++;
 // 1B000..1B0FF; Kana Supplement
 	c = 0x1b000;		// from KATAKANA LETTER ARCHAIC E
@@ -1953,6 +2010,12 @@ void init()
 // 1B100..1B12F; Kana Extended-A
 	c = 0x1b100;		// from HENTAIGANA LETTER RE-3
 	while (c <= 0x1b11e)	// ..to HENTAIGANA LETTER N-MU-MO-2
+		charset[i++] = c++;
+// 1B130..1B16F; Small Kana Extension
+	charset[i++] = 0x1b150;	// HIRAGANA LETTER SMALL WI
+	charset[i++] = 0x1b152;	// HIRAGANA LETTER SMALL WO
+	c = 0x1b164;		// from KATAKANA LETTER SMALL WI
+	while (c <= 0x1b167)	// ..to KATAKANA LETTER SMALL N
 		charset[i++] = c++;
 // 1B170..1B2FF; Nushu
 	c = 0x1b170;		// from NUSHU CHARACTER-1B170
@@ -2083,6 +2146,23 @@ void init()
 	c = 0x1e026;		// from COMBINING GLAGOLITIC LETTER YO
 	while (c <= 0x1e02a)	// ..to COMBINING GLAGOLITIC LETTER FITA
 		charset[i++] = c++;
+// 1E100..1E14F; Nyiakeng Puachue Hmong
+	c = 0x1e100;		// from NYIAKENG PUACHUE HMONG LETTER MA
+	while (c <= 0x1e12c)	// ..to NYIAKENG PUACHUE HMONG LETTER W
+		charset[i++] = c++;
+	c = 0x1e130;		// from NYIAKENG PUACHUE HMONG TONE-B
+	while (c <= 0x1e13d)	// ..to NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+		charset[i++] = c++;
+	c = 0x1e140;		// from NYIAKENG PUACHUE HMONG DIGIT ZERO
+	while (c <= 0x1e149)	// ..to NYIAKENG PUACHUE HMONG DIGIT NINE
+		charset[i++] = c++;
+	charset[i++] = 0x1e14e;	// NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+	charset[i++] = 0x1e14f;	// NYIAKENG PUACHUE HMONG CIRCLED CA
+// 1E2C0..1E2FF; Wancho
+	c = 0x1e2c0;		// from WANCHO LETTER AA
+	while (c <= 0x1e2f9)	// ..to WANCHO DIGIT NINE
+		charset[i++] = c++;
+	charset[i++] = 0x1e2ff;	// WANCHO NGUN SIGN
 // 1E800..1E8DF; Mende Kikakui
 	c = 0x1e800;		// from MENDE KIKAKUI SYLLABLE M001 KI
 	while (c <= 0x1e8c4)	// ..to MENDE KIKAKUI SYLLABLE M060 NYON
@@ -2092,7 +2172,7 @@ void init()
 		charset[i++] = c++;
 // 1E900..1E95F; Adlam
 	c = 0x1e900;		// from ADLAM CAPITAL LETTER ALIF
-	while (c <= 0x1e94a)	// ..to ADLAM NUKTA
+	while (c <= 0x1e94b)	// ..to ADLAM NASALIZATION MARK
 		charset[i++] = c++;
 	c = 0x1e950;		// from ADLAM DIGIT ZERO
 	while (c <= 0x1e959)	// ..to ADLAM DIGIT NINE
@@ -2102,6 +2182,10 @@ void init()
 // 1EC70..1ECBF; Indic Siyaq Numbers
 	c = 0x1ec71;		// from INDIC SIYAQ NUMBER ONE
 	while (c <= 0x1ecb4)	// ..to INDIC SIYAQ ALTERNATE LAKH MARK
+		charset[i++] = c++;
+// 1ED00..1ED4F; Ottoman Siyaq Numbers
+	c = 0x1ed01;		// from OTTOMAN SIYAQ NUMBER ONE
+	while (c <= 0x1ed3d)	// ..to OTTOMAN SIYAQ FRACTION ONE SIXTH
 		charset[i++] = c++;
 // 1EE00..1EEFF; Arabic Mathematical Alphabetic Symbols
 	c = 0x1ee00;		// from ARABIC MATHEMATICAL ALEF
@@ -2175,13 +2259,7 @@ void init()
 		charset[i++] = c++;
 // 1F100..1F1FF; Enclosed Alphanumeric Supplement
 	c = 0x1f100;		// from DIGIT ZERO FULL STOP
-	while (c <= 0x1f10c)	// ..to DINGBAT NEGATIVE CIRCLED SANS-SERIF DIGIT ZERO
-		charset[i++] = c++;
-	c = 0x1f110;		// from PARENTHESIZED LATIN CAPITAL LETTER A
-	while (c <= 0x1f16b)	// ..to RAISED MD SIGN
-		charset[i++] = c++;
-	c = 0x1f170;		// from NEGATIVE SQUARED LATIN CAPITAL LETTER A
-	while (c <= 0x1f1ac)	// ..to SQUARED VOD
+	while (c <= 0x1f1ad)	// ..to MASK WORK SYMBOL
 		charset[i++] = c++;
 	c = 0x1f1e6;		// from REGIONAL INDICATOR SYMBOL LETTER A
 	while (c <= 0x1f1ff)	// ..to REGIONAL INDICATOR SYMBOL LETTER Z
@@ -2214,13 +2292,13 @@ void init()
 		charset[i++] = c++;
 // 1F680..1F6FF; Transport and Map Symbols
 	c = 0x1f680;		// from ROCKET
-	while (c <= 0x1f6d4)	// ..to PAGODA
+	while (c <= 0x1f6d7)	// ..to ELEVATOR
 		charset[i++] = c++;
 	c = 0x1f6e0;		// from HAMMER AND WRENCH
 	while (c <= 0x1f6ec)	// ..to AIRPLANE ARRIVING
 		charset[i++] = c++;
 	c = 0x1f6f0;		// from SATELLITE
-	while (c <= 0x1f6f9)	// ..to SKATEBOARD
+	while (c <= 0x1f6fc)	// ..to ROLLER SKATE
 		charset[i++] = c++;
 // 1F700..1F77F; Alchemical Symbols
 	c = 0x1f700;		// from ALCHEMICAL SYMBOL FOR QUINTESSENCE
@@ -2229,6 +2307,9 @@ void init()
 // 1F780..1F7FF; Geometric Shapes Extended
 	c = 0x1f780;		// from BLACK LEFT-POINTING ISOSCELES RIGHT TRIANGLE
 	while (c <= 0x1f7d8)	// ..to NEGATIVE CIRCLED SQUARE
+		charset[i++] = c++;
+	c = 0x1f7e0;		// from LARGE ORANGE CIRCLE
+	while (c <= 0x1f7eb)	// ..to LARGE BROWN SQUARE
 		charset[i++] = c++;
 // 1F800..1F8FF; Supplemental Arrows-C
 	c = 0x1f800;		// from LEFTWARDS ARROW WITH SMALL TRIANGLE ARROWHEAD
@@ -2246,37 +2327,58 @@ void init()
 	c = 0x1f890;		// from LEFTWARDS TRIANGLE ARROWHEAD
 	while (c <= 0x1f8ad)	// ..to WHITE ARROW SHAFT WIDTH TWO THIRDS
 		charset[i++] = c++;
+	charset[i++] = 0x1f8b0;	// ARROW POINTING UPWARDS THEN NORTH WEST
+	charset[i++] = 0x1f8b1;	// ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
 // 1F900..1F9FF; Supplemental Symbols and Pictographs
 	c = 0x1f900;		// from CIRCLED CROSS FORMEE WITH FOUR DOTS
-	while (c <= 0x1f90b)	// ..to DOWNWARD FACING NOTCHED HOOK WITH DOT
+	while (c <= 0x1f978)	// ..to DISGUISED FACE
 		charset[i++] = c++;
-	c = 0x1f910;		// from ZIPPER-MOUTH FACE
-	while (c <= 0x1f93e)	// ..to HANDBALL
+	c = 0x1f97a;		// from FACE WITH PLEADING EYES
+	while (c <= 0x1f9cb)	// ..to BUBBLE TEA
 		charset[i++] = c++;
-	c = 0x1f940;		// from WILTED FLOWER
-	while (c <= 0x1f970)	// ..to SMILING FACE WITH SMILING EYES AND THREE HEARTS
-		charset[i++] = c++;
-	c = 0x1f973;		// from FACE WITH PARTY HORN AND PARTY HAT
-	while (c <= 0x1f976)	// ..to FREEZING FACE
-		charset[i++] = c++;
-	c = 0x1f97c;		// from LAB COAT
-	while (c <= 0x1f9a2)	// ..to SWAN
-		charset[i++] = c++;
-	c = 0x1f9b0;		// from EMOJI COMPONENT RED HAIR
-	while (c <= 0x1f9b9)	// ..to SUPERVILLAIN
-		charset[i++] = c++;
-	charset[i++] = 0x1f9c0;	// CHEESE WEDGE
-	charset[i++] = 0x1f9c2;	// SALT SHAKER
-	c = 0x1f9d0;		// from FACE WITH MONOCLE
+	c = 0x1f9cd;		// from STANDING PERSON
 	while (c <= 0x1f9ff)	// ..to NAZAR AMULET
 		charset[i++] = c++;
 // 1FA00..1FA6F; Chess Symbols
+	c = 0x1fa00;		// from NEUTRAL CHESS KING
+	while (c <= 0x1fa53)	// ..to BLACK CHESS KNIGHT-BISHOP
+		charset[i++] = c++;
 	c = 0x1fa60;		// from XIANGQI RED GENERAL
 	while (c <= 0x1fa6d)	// ..to XIANGQI BLACK SOLDIER
 		charset[i++] = c++;
+// 1FA70..1FAFF; Symbols and Pictographs Extended-A
+	c = 0x1fa70;		// from BALLET SHOES
+	while (c <= 0x1fa74)	// ..to THONG SANDAL
+		charset[i++] = c++;
+	charset[i++] = 0x1fa78;	// DROP OF BLOOD
+	charset[i++] = 0x1fa7a;	// STETHOSCOPE
+	c = 0x1fa80;		// from YO-YO
+	while (c <= 0x1fa86)	// ..to NESTING DOLLS
+		charset[i++] = c++;
+	c = 0x1fa90;		// from RINGED PLANET
+	while (c <= 0x1faa8)	// ..to ROCK
+		charset[i++] = c++;
+	c = 0x1fab0;		// from FLY
+	while (c <= 0x1fab6)	// ..to FEATHER
+		charset[i++] = c++;
+	charset[i++] = 0x1fac0;	// ANATOMICAL HEART
+	charset[i++] = 0x1fac2;	// PEOPLE HUGGING
+	c = 0x1fad0;		// from BLUEBERRIES
+	while (c <= 0x1fad6)	// ..to TEAPOT
+		charset[i++] = c++;
+// 1FB00..1FBFF; Symbols for Legacy Computing
+	c = 0x1fb00;		// from BLOCK SEXTANT-1
+	while (c <= 0x1fb92)	// ..to UPPER HALF INVERSE MEDIUM SHADE AND LOWER HALF BLOCK
+		charset[i++] = c++;
+	c = 0x1fb94;		// from LEFT HALF INVERSE MEDIUM SHADE AND RIGHT HALF BLOCK
+	while (c <= 0x1fbca)	// ..to WHITE UP-POINTING CHEVRON
+		charset[i++] = c++;
+	c = 0x1fbf0;		// from SEGMENTED DIGIT ZERO
+	while (c <= 0x1fbf9)	// ..to SEGMENTED DIGIT NINE
+		charset[i++] = c++;
 // 20000..2A6DF; CJK Unified Ideographs Extension B
 	c = 0x20000;		// from <CJK Ideograph Extension B, First>
-	while (c <= 0x2a6d6)	// ..to <CJK Ideograph Extension B, Last>
+	while (c <= 0x2a6dd)	// ..to <CJK Ideograph Extension B, Last>
 		charset[i++] = c++;
 // 2A700..2B73F; CJK Unified Ideographs Extension C
 	c = 0x2a700;		// from <CJK Ideograph Extension C, First>
@@ -2297,6 +2399,10 @@ void init()
 // 2F800..2FA1F; CJK Compatibility Ideographs Supplement
 	c = 0x2f800;		// from CJK COMPATIBILITY IDEOGRAPH-2F800
 	while (c <= 0x2fa1d)	// ..to CJK COMPATIBILITY IDEOGRAPH-2FA1D
+		charset[i++] = c++;
+// 30000..3134F; CJK Unified Ideographs Extension G
+	c = 0x30000;		// from <CJK Ideograph Extension G, First>
+	while (c <= 0x3134a)	// ..to <CJK Ideograph Extension G, Last>
 		charset[i++] = c++;
 // E0000..E007F; Tags
 	c = 0xe0020;		// from TAG SPACE

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -1,7 +1,6 @@
 module Metasploit
   module Framework
     module PasswordCracker
-
       class PasswordCrackerNotFoundError < StandardError
       end
 
@@ -84,38 +83,38 @@ module Metasploit
         #   @return [String] The file path to the wordlist to use
         attr_accessor :wordlist
 
-        validates :config, :'Metasploit::Framework::File_path' => true, if: -> { config.present? }
+        validates :config, 'Metasploit::Framework::File_path': true, if: -> { config.present? }
 
-        validates :cracker, inclusion: {in: %w[john hashcat]}
+        validates :cracker, inclusion: { in: %w[john hashcat] }
 
-        validates :cracker_path, :'Metasploit::Framework::Executable_path' => true, if: -> { cracker_path.present? }
+        validates :cracker_path, 'Metasploit::Framework::Executable_path': true, if: -> { cracker_path.present? }
 
         validates :fork,
                   numericality: {
-                      only_integer:             true,
-                      greater_than_or_equal_to: 1
+                    only_integer: true,
+                    greater_than_or_equal_to: 1
                   }, if: -> { fork.present? }
 
-        validates :hash_path, :'Metasploit::Framework::File_path' => true, if: -> { hash_path.present? }
+        validates :hash_path, 'Metasploit::Framework::File_path': true, if: -> { hash_path.present? }
 
-        validates :pot, :'Metasploit::Framework::File_path' => true, if: -> { pot.present? }
+        validates :pot, 'Metasploit::Framework::File_path': true, if: -> { pot.present? }
 
         validates :max_runtime,
                   numericality: {
-                      only_integer:             true,
-                      greater_than_or_equal_to: 0
+                    only_integer: true,
+                    greater_than_or_equal_to: 0
                   }, if: -> { max_runtime.present? }
 
         validates :max_length,
                   numericality: {
-                      only_integer:             true,
-                      greater_than_or_equal_to: 0
+                    only_integer: true,
+                    greater_than_or_equal_to: 0
                   }, if: -> { max_length.present? }
 
-        validates :wordlist, :'Metasploit::Framework::File_path' => true, if: -> { wordlist.present? }
+        validates :wordlist, 'Metasploit::Framework::File_path': true, if: -> { wordlist.present? }
 
         # @param attributes [Hash{Symbol => String,nil}]
-        def initialize(attributes={})
+        def initialize(attributes = {})
           attributes.each do |attribute, value|
             public_send("#{attribute}=", value)
           end
@@ -152,7 +151,7 @@ module Metasploit
             '1731'
           # hashcat requires a format we dont have all the data for
           # in the current dumper, so this is disabled in module and lib
-          #when 'oracle', 'des,oracle'
+          # when 'oracle', 'des,oracle'
           #  return '3100'
           when 'oracle11', 'raw-sha1,oracle'
             '112'
@@ -203,16 +202,13 @@ module Metasploit
           when 'ssha512'
             '1711'
           when 'mscash'
-              '1100'
+            '1100'
           when 'mscash2'
-              '2100'
+            '2100'
           when 'Raw-MD5u'
-              '30'
-          else
-            nil
+            '30'
           end
         end
-
 
         # This method sets the appropriate parameters to run a cracker in incremental mode
         def mode_incremental
@@ -228,7 +224,6 @@ module Metasploit
             self.incremental = true
           end
         end
-
 
         # This method sets the appropriate parameters to run a cracker in wordlist mode
         #
@@ -247,19 +242,17 @@ module Metasploit
           end
         end
 
-
         # This method sets the appropriate parameters to run a cracker in a pin mode (4-8 digits) on hashcat
         def mode_pin
           self.rules = nil
           if cracker == 'hashcat'
             self.attack = '3'
-            self.mask = '?d'*8
+            self.mask = '?d' * 8
             self.incremental = true
-            self.increment_length = [4,8]
-            self.max_runtime = 300 #5min on an i7 got through 4-7 digits. 8digit was 32min more
+            self.increment_length = [4, 8]
+            self.max_runtime = 300 # 5min on an i7 got through 4-7 digits. 8digit was 32min more
           end
         end
-
 
         # This method sets the john to 'normal' mode
         def mode_normal
@@ -272,7 +265,6 @@ module Metasploit
             self.increment_length = nil
           end
         end
-
 
         # This method sets the john to single mode
         #
@@ -287,7 +279,6 @@ module Metasploit
           end
         end
 
-
         # This method follows a decision tree to determine the path
         # to the cracker binary we should use.
         #
@@ -300,11 +291,11 @@ module Metasploit
           else
             # Look in the Environment PATH for the john binary
             if cracker == 'john'
-              path = Rex::FileUtils.find_full_path("john") ||
-                Rex::FileUtils.find_full_path("john.exe")
+              path = Rex::FileUtils.find_full_path('john') ||
+                     Rex::FileUtils.find_full_path('john.exe')
             elsif cracker == 'hashcat'
-              path = Rex::FileUtils.find_full_path("hashcat") ||
-                Rex::FileUtils.find_full_path("hashcat.exe")
+              path = Rex::FileUtils.find_full_path('hashcat') ||
+                     Rex::FileUtils.find_full_path('hashcat.exe')
             else
               raise PasswordCrackerNotFoundError, 'No suitable Cracker was selected, so a binary could not be found on the system'
             end
@@ -321,16 +312,14 @@ module Metasploit
         #
         # @yield [String] a line of output from the cracker command
         # @return [void]
-        def crack
+        def crack(&block)
           if cracker == 'john'
             results = john_crack_command
           elsif cracker == 'hashcat'
             results = hashcat_crack_command
           end
-          ::IO.popen(results, "rb") do |fd|
-            fd.each_line do |line|
-              yield line
-            end
+          ::IO.popen(results, 'rb') do |fd|
+            fd.each_line(&block)
           end
         end
 
@@ -343,23 +332,45 @@ module Metasploit
             cmd = binary_path
           elsif cracker == 'hashcat'
             cmd = binary_path
-            cmd << (" -V")
+            cmd << (' -V')
           end
-          ::IO.popen(cmd, "rb") do |fd|
+          ::IO.popen(cmd, 'rb') do |fd|
             fd.each_line do |line|
               if cracker == 'john'
                 # John the Ripper 1.8.0.13-jumbo-1-bleeding-973a245b96 2018-12-17 20:12:51 +0100 OMP [linux-gnu 64-bit x86_64 AVX2 AC]
                 # John the Ripper 1.9.0-jumbo-1 OMP [linux-gnu 64-bit x86_64 AVX2 AC]
                 # John the Ripper password cracker, version 1.8.0.2-bleeding-jumbo_omp [64-bit AVX-autoconf]
                 # John the Ripper password cracker, version 1.8.0
-                return $1.strip if line =~ /John the Ripper(?: password cracker, version)? ([^\[]+)/
+                return Regexp.last_match(1).strip if line =~ /John the Ripper(?: password cracker, version)? ([^\[]+)/
               elsif cracker == 'hashcat'
                 # v5.1.0
-                return $1 if line =~ /(v[\d\.]+)/
+                return Regexp.last_match(1) if line =~ /(v[\d.]+)/
               end
             end
           end
           nil
+        end
+
+        # This method is used to determine which format of the no log option should be used
+        # --no-log vs --nolog https://github.com/openwall/john/commit/8982e4f7a2e874aab29807a05b421373015c9b61
+        # We base this either on a date being in the version, or running the command and checking the output
+        #
+        # @return [String] The nolog format to use
+        def john_nolog_format
+          if /(\d{4}-\d{2}-\d{2})/ =~ cracker_version
+            # we lucked out and theres a date, we'll check its older than the commit that changed the nolog
+            if Date.parse(Regexp.last_match(1)) < Date.parse('2020-11-27')
+              return '--nolog'
+            end
+
+            return '--no-log'
+          end
+
+          # no date, so lets give it a run with the old format and check if we raise an error
+          ::IO.popen([binary_path, '--nolog', { err: %i[child out] }], 'rb') do |fd|
+            return '--nolog' unless fd.read.include? 'Unknown option'
+          end
+          '--no-log'
         end
 
         # This method builds an array for the command to actually run the cracker.
@@ -369,46 +380,47 @@ module Metasploit
         # @return [Array] An array set up for {::IO.popen} to use
         def john_crack_command
           cmd_string = binary_path
-          cmd = [cmd_string,  '--session=' + cracker_session_id, '--no-log']
+
+          cmd = [cmd_string, '--session=' + cracker_session_id]
 
           if config.present?
-            cmd << ("--config=" + config)
+            cmd << ('--config=' + config)
           else
-            cmd << ("--config=" + john_config_file)
+            cmd << ('--config=' + john_config_file)
           end
 
           if pot.present?
-            cmd << ("--pot=" + pot)
+            cmd << ('--pot=' + pot)
           else
-            cmd << ("--pot=" + john_pot_file)
+            cmd << ('--pot=' + john_pot_file)
           end
 
           if fork.present? && fork > 1
-            cmd << ("--fork=" + fork.to_s)
+            cmd << ('--fork=' + fork.to_s)
           end
 
           if format.present?
-            cmd << ("--format=" + format)
+            cmd << ('--format=' + format)
           end
 
           if wordlist.present?
-            cmd << ("--wordlist=" + wordlist)
+            cmd << ('--wordlist=' + wordlist)
           end
 
           if incremental.present?
-            cmd << ("--incremental=" + incremental)
+            cmd << ('--incremental=' + incremental)
           end
 
           if rules.present?
-            cmd << ("--rules=" + rules)
+            cmd << ('--rules=' + rules)
           end
 
           if max_runtime.present?
-            cmd << ("--max-run-time=" + max_runtime.to_s)
+            cmd << ('--max-run-time=' + max_runtime.to_s)
           end
 
           if max_length.present?
-            cmd << ("--max-len=" + max_length.to_s)
+            cmd << ('--max-len=' + max_length.to_s)
           end
 
           cmd << hash_path
@@ -421,16 +433,16 @@ module Metasploit
         # @return [Array] An array set up for {::IO.popen} to use
         def hashcat_crack_command
           cmd_string = binary_path
-          cmd = [cmd_string,  '--session=' + cracker_session_id, '--logfile-disable']
+          cmd = [cmd_string, '--session=' + cracker_session_id, '--logfile-disable']
 
           if pot.present?
-            cmd << ("--potfile-path=" + pot)
+            cmd << ('--potfile-path=' + pot)
           else
-            cmd << ("--potfile-path=" + john_pot_file)
+            cmd << ('--potfile-path=' + john_pot_file)
           end
 
           if format.present?
-            cmd << ("--hash-type=" + jtr_format_to_hashcat_format(format))
+            cmd << ('--hash-type=' + jtr_format_to_hashcat_format(format))
           end
 
           if optimize.present?
@@ -459,33 +471,33 @@ module Metasploit
             # wouldn't be tested inside of MSF since most users are using the MSF modules for word list and easy cracks.
             # Anything of length where this would cut off is most likely being done independently (outside MSF)
 
-            cmd << ("-O")
+            cmd << ('-O')
           end
 
           if incremental.present?
-            cmd << ("--increment")
+            cmd << ('--increment')
             if increment_length.present?
-              cmd << ("--increment-min=" + increment_length[0].to_s)
-              cmd << ("--increment-max=" + increment_length[1].to_s)
+              cmd << ('--increment-min=' + increment_length[0].to_s)
+              cmd << ('--increment-max=' + increment_length[1].to_s)
             else
               # anything more than max 4 on even des took 8+min on an i7.
               # maybe in the future this can be adjusted or made a variable
               # but current time, we'll leave it as this seems like reasonable
               # time expectation for a module to run
-              cmd << ("--increment-max=4")
+              cmd << ('--increment-max=4')
             end
           end
 
           if rules.present?
-            cmd << ("--rules-file=" + rules)
+            cmd << ('--rules-file=' + rules)
           end
 
           if attack.present?
-            cmd << ("--attack-mode=" + attack)
+            cmd << ('--attack-mode=' + attack)
           end
 
           if max_runtime.present?
-            cmd << ("--runtime=" + max_runtime.to_s)
+            cmd << ('--runtime=' + max_runtime.to_s)
           end
 
           cmd << hash_path
@@ -505,21 +517,21 @@ module Metasploit
         #
         # @return [Array] the output from teh command split on newlines
         def each_cracked_password
-          ::IO.popen(show_command, "rb").readlines
+          ::IO.popen(show_command, 'rb').readlines
         end
 
         # This method returns the path to a default john.conf file.
         #
         # @return [String] the path to the default john.conf file
         def john_config_file
-          ::File.join(::Msf::Config.data_directory, "jtr", "john.conf")
+          ::File.join(::Msf::Config.data_directory, 'jtr', 'john.conf')
         end
 
         # This method returns the path to a default john.pot file.
         #
         # @return [String] the path to the default john.pot file
         def john_pot_file
-          ::File.join(::Msf::Config.config_directory, "john.pot")
+          ::File.join(::Msf::Config.config_directory, 'john.pot')
         end
 
         # This method is a getter for a random Session ID for the cracker.
@@ -538,24 +550,21 @@ module Metasploit
           cmd_string = binary_path
 
           pot_file = pot || john_pot_file
-          if cracker=='hashcat'
-            cmd = [cmd_string, "--show", "--potfile-path=#{pot_file}", "--hash-type=#{jtr_format_to_hashcat_format(format)}"]
-          elsif cracker=='john'
-            cmd = [cmd_string, "--show", "--pot=#{pot_file}", "--format=#{format}"]
+          if cracker == 'hashcat'
+            cmd = [cmd_string, '--show', "--potfile-path=#{pot_file}", "--hash-type=#{jtr_format_to_hashcat_format(format)}"]
+          elsif cracker == 'john'
+            cmd = [cmd_string, '--show', "--pot=#{pot_file}", "--format=#{format}"]
 
             if config
               cmd << "--config=#{config}"
             else
-              cmd << ("--config=" + john_config_file)
+              cmd << ('--config=' + john_config_file)
             end
           end
           cmd << hash_path
         end
 
-        private
-
       end
-
     end
   end
 end

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -367,6 +367,7 @@ module Metasploit
           end
 
           # no date, so lets give it a run with the old format and check if we raise an error
+          # on *nix 'unknown option' goes to stderr
           ::IO.popen([binary_path, '--nolog', { err: %i[child out] }], 'rb') do |fd|
             return '--nolog' unless fd.read.include? 'Unknown option'
           end
@@ -381,7 +382,7 @@ module Metasploit
         def john_crack_command
           cmd_string = binary_path
 
-          cmd = [cmd_string, '--session=' + cracker_session_id]
+          cmd = [cmd_string, '--session=' + cracker_session_id, john_nolog_format]
 
           if config.present?
             cmd << ('--config=' + config)

--- a/spec/lib/metasploit/framework/password_crackers/cracker_spec.rb
+++ b/spec/lib/metasploit/framework/password_crackers/cracker_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'metasploit/framework/password_crackers/cracker'
 
 RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
-
   subject(:cracker) { described_class.new }
   let(:cracker_type) { 'john' }
   let(:cracker_path) { '/path/to/john' }
@@ -15,12 +14,10 @@ RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
   let(:hash_path) { '/path/to/hashes' }
   let(:nt_format) { 'nt' }
   let(:incremental) { 'Digits5' }
-  let(:rules)   { 'Rule34'}
+  let(:rules) { 'Rule34' }
   let(:max_runtime) { 5000 }
 
   describe '#binary_path' do
-
-
     context 'when the user supplied a cracker_path' do
       before(:example) do
         cracker.cracker_path = cracker_path
@@ -60,9 +57,9 @@ RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
     end
 
     it 'returns 1000 for nt' do
-      expect(cracker.jtr_format_to_hashcat_format('nt')).to eq "1000"
+      expect(cracker.jtr_format_to_hashcat_format('nt')).to eq '1000'
     end
-  end    
+  end
 
   describe '#john_crack_command' do
     before(:example) do
@@ -80,7 +77,7 @@ RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
     end
 
     it 'sets the nolog flag' do
-      expect(cracker.john_crack_command).to include '--nolog'
+      expect(cracker.john_crack_command).to include '--no-log'
     end
 
     it 'adds a config directive if the user supplied one' do
@@ -124,14 +121,13 @@ RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
 
     it 'uses the user supplied max-run-time' do
       cracker.max_runtime = max_runtime
-      expect(cracker.john_crack_command).to include "--max-run-time=#{max_runtime.to_s}"
+      expect(cracker.john_crack_command).to include "--max-run-time=#{max_runtime}"
     end
 
     it 'puts the path to the has file at the end' do
       cracker.hash_path = hash_path
       expect(cracker.john_crack_command.last).to eq hash_path
     end
-
   end
 
   describe '#show_command' do
@@ -180,25 +176,25 @@ RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
         it 'produces the correct error message for config' do
           cracker.config = config
           expect(cracker).to_not be_valid
-          expect(cracker.errors[:config]).to include "is not a valid path to a regular file"
+          expect(cracker.errors[:config]).to include 'is not a valid path to a regular file'
         end
 
         it 'produces the correct error message for hash_path' do
           cracker.hash_path = hash_path
           expect(cracker).to_not be_valid
-          expect(cracker.errors[:hash_path]).to include "is not a valid path to a regular file"
+          expect(cracker.errors[:hash_path]).to include 'is not a valid path to a regular file'
         end
 
         it 'produces the correct error message for pot' do
           cracker.pot = pot
           expect(cracker).to_not be_valid
-          expect(cracker.errors[:pot]).to include "is not a valid path to a regular file"
+          expect(cracker.errors[:pot]).to include 'is not a valid path to a regular file'
         end
 
         it 'produces the correct error message for wordlist' do
           cracker.wordlist = wordlist
           expect(cracker).to_not be_valid
-          expect(cracker.errors[:wordlist]).to include "is not a valid path to a regular file"
+          expect(cracker.errors[:wordlist]).to include 'is not a valid path to a regular file'
         end
       end
 
@@ -211,7 +207,7 @@ RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
         it 'produces the correct error message for cracker_path' do
           cracker.cracker_path = cracker_path
           expect(cracker).to_not be_valid
-          expect(cracker.errors[:cracker_path]).to include "is not a valid path to an executable file"
+          expect(cracker.errors[:cracker_path]).to include 'is not a valid path to an executable file'
         end
       end
     end
@@ -226,25 +222,25 @@ RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
         it 'produces no error message for config' do
           cracker.config = config
           expect(cracker).to be_valid
-          expect(cracker.errors[:config]).to_not include "is not a valid path to a regular file"
+          expect(cracker.errors[:config]).to_not include 'is not a valid path to a regular file'
         end
 
         it 'produces no error message for hash_path' do
           cracker.hash_path = hash_path
           expect(cracker).to be_valid
-          expect(cracker.errors[:hash_path]).to_not include "is not a valid path to a regular file"
+          expect(cracker.errors[:hash_path]).to_not include 'is not a valid path to a regular file'
         end
 
         it 'produces no error message for pot' do
           cracker.pot = pot
           expect(cracker).to be_valid
-          expect(cracker.errors[:pot]).to_not include "is not a valid path to a regular file"
+          expect(cracker.errors[:pot]).to_not include 'is not a valid path to a regular file'
         end
 
         it 'produces no error message for wordlist' do
           cracker.wordlist = wordlist
           expect(cracker).to be_valid
-          expect(cracker.errors[:wordlist]).to_not include "is not a valid path to a regular file"
+          expect(cracker.errors[:wordlist]).to_not include 'is not a valid path to a regular file'
         end
       end
 
@@ -257,7 +253,7 @@ RSpec.describe Metasploit::Framework::PasswordCracker::Cracker do
         it 'produces no error message for cracker_path' do
           cracker.cracker_path = cracker_path
           expect(cracker).to be_valid
-          expect(cracker.errors[:cracker_path]).to_not include "is not a valid path to an executable file"
+          expect(cracker.errors[:cracker_path]).to_not include 'is not a valid path to an executable file'
         end
       end
     end


### PR DESCRIPTION
1. rubocop on cracker
2. updates john conf files
3. implements `john_nolog_format` to make an educated guess at which format of `no-log` to use
4. updates the spec and adds tests for `john_nolog_format`

[#https://github.com/rapid7/metasploit-framework/pull/16054](https://github.com/rapid7/metasploit-framework/pull/16054)